### PR TITLE
fix(display): hide write_file tool output

### DIFF
--- a/src/mini_agent/display.py
+++ b/src/mini_agent/display.py
@@ -62,6 +62,7 @@ def print_tool_result(name: str, input_data: dict[str, Any], output: str) -> Non
         return
 
     if name == "write_file":
+        print(f"> {name} - {input_data['path']}\n")
         return
 
     if name == "bash":


### PR DESCRIPTION
## Summary
- hide write_file tool output in display.py

## Testing
- pre-commit hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show only the `write_file` path in the tool result display, hiding file contents and output to reduce noise and prevent content leaks.

<sup>Written for commit 2b05e9aac78ff7bf9a68606c48666e7dcd72bd86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

