### PR TITLE
feat(cli): keep input responsive and support interrupting runs

### DIFF
--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -1,3 +1,5 @@
+import threading
+
 import anthropic
 from anthropic.types import MessageParam, ThinkingBlock, ToolUseBlock
 
@@ -20,10 +22,18 @@ Available skills:
 """
 
 
-def agent_loop(messages: list[MessageParam]) -> None:
+def agent_loop(
+    messages: list[MessageParam],
+    cancel: threading.Event | None = None,
+) -> None:
     rounds_since_todo = 0
 
     while True:
+        if cancel is not None and cancel.is_set():
+            cancel.clear()
+            print("Interrupted.\n")
+            return
+
         try:
             response = client.messages.create(
                 model=get_model(),
@@ -52,6 +62,12 @@ def agent_loop(messages: list[MessageParam]) -> None:
         used_todo = False
         results = []
         for block in response.content:
+            if cancel is not None and cancel.is_set():
+                cancel.clear()
+                messages.pop()
+                print("Interrupted.\n")
+                return
+
             if isinstance(block, ToolUseBlock):
                 handler = TOOL_HANDLERS.get(block.name)
                 output = (

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -25,7 +25,10 @@ from .models import prompt_model
 from .sessions import prompt_resume, save_session_history
 
 
-def build_session(agent_running: threading.Event) -> tuple[PromptSession, object]:
+def build_session(
+    agent_running: threading.Event,
+    cancel: threading.Event,
+) -> tuple[PromptSession, object]:
     bindings = KeyBindings()
     last_ctrl_c = 0.0
     hint_refresh_timer: threading.Timer | None = None
@@ -41,6 +44,10 @@ def build_session(agent_running: threading.Event) -> tuple[PromptSession, object
     @bindings.add("c-c")
     def clear_buffer(event: KeyPressEvent) -> None:
         nonlocal last_ctrl_c, hint_refresh_timer
+
+        if agent_running.is_set():
+            cancel.set()
+            return
 
         now = time.monotonic()
         if now - last_ctrl_c <= ctrl_c_timeout:
@@ -88,7 +95,8 @@ def main() -> None:
     history: list[MessageParam] = []
     current_session_id = uuid.uuid4().hex
     agent_running = threading.Event()
-    session, exit_sentinel = build_session(agent_running)
+    cancel = threading.Event()
+    session, exit_sentinel = build_session(agent_running, cancel)
     msg_queue: queue.Queue[str | None] = queue.Queue()
 
     def agent_worker() -> None:
@@ -104,7 +112,8 @@ def main() -> None:
 
             history.append({"role": "user", "content": query})
             history_len = len(history)
-            agent_loop(history)
+            agent_loop(history, cancel=cancel)
+            cancel.clear()
 
             if len(history) > history_len:
                 save_session_history(current_session_id, history)

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -1,12 +1,15 @@
+import queue
 import threading
 import time
 import uuid
+from contextlib import suppress
 
 from anthropic.types import MessageParam
 from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import HTML, FormattedText
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+from prompt_toolkit.patch_stdout import patch_stdout
 
 from ..agent.agent import agent_loop
 from .display import (
@@ -22,7 +25,7 @@ from .models import prompt_model
 from .sessions import prompt_resume, save_session_history
 
 
-def build_session() -> tuple[PromptSession, object]:
+def build_session(agent_running: threading.Event) -> tuple[PromptSession, object]:
     bindings = KeyBindings()
     last_ctrl_c = 0.0
     hint_refresh_timer: threading.Timer | None = None
@@ -74,6 +77,7 @@ def build_session() -> tuple[PromptSession, object]:
             complete_while_typing=True,
             style=COMPLETION_STYLE,
             bottom_toolbar=status_toolbar,
+            reserve_space_for_menu=2,
         ),
         exit_sentinel,
     )
@@ -83,46 +87,69 @@ def main() -> None:
     print_welcome_banner()
     history: list[MessageParam] = []
     current_session_id = uuid.uuid4().hex
-    session, exit_sentinel = build_session()
+    agent_running = threading.Event()
+    session, exit_sentinel = build_session(agent_running)
+    msg_queue: queue.Queue[str | None] = queue.Queue()
 
-    while True:
-        try:
-            query = session.prompt()
-            print()
-        except KeyboardInterrupt:
-            continue
-        except EOFError:
-            break
+    def agent_worker() -> None:
+        nonlocal current_session_id
+        while True:
+            query = msg_queue.get()
+            if query is None:
+                break
 
-        if query is exit_sentinel:
-            break
+            agent_running.set()
+            with suppress(Exception):
+                session.app.invalidate()
 
-        command = query.strip().lower()
-        if command in {"", "q", "exit"}:
-            break
-        if command == "/new":
-            history.clear()
-            current_session_id = uuid.uuid4().hex
-            clear_terminal()
-            continue
-        if command == "/resume":
-            current_session_id, history = prompt_resume(current_session_id, history)
-            continue
-        if command == "/model":
-            prompt_model()
-            continue
+            history.append({"role": "user", "content": query})
+            history_len = len(history)
+            agent_loop(history)
 
-        history.append({"role": "user", "content": query})
-        history_len = len(history)
-        agent_loop(history)
+            if len(history) > history_len:
+                save_session_history(current_session_id, history)
+                response_content = history[-1]["content"]
+                if isinstance(response_content, list):
+                    for block in response_content:
+                        if hasattr(block, "text"):
+                            print(f"> {block.text}\n")
 
-        if len(history) <= history_len:
-            continue
+            agent_running.clear()
+            with suppress(Exception):
+                session.app.invalidate()
 
-        save_session_history(current_session_id, history)
+    worker = threading.Thread(target=agent_worker, daemon=True)
+    worker.start()
 
-        response_content = history[-1]["content"]
-        if isinstance(response_content, list):
-            for block in response_content:
-                if hasattr(block, "text"):
-                    print(f"> {block.text}\n")
+    with patch_stdout(raw=True):
+        while True:
+            try:
+                query = session.prompt()
+                print()
+            except KeyboardInterrupt:
+                continue
+            except EOFError:
+                break
+
+            if query is exit_sentinel:
+                break
+
+            command = query.strip().lower()
+            if command in {"", "q", "exit"}:
+                break
+            if command == "/new":
+                history.clear()
+                current_session_id = uuid.uuid4().hex
+                clear_terminal()
+                continue
+            if command == "/resume":
+                current_session_id, history = prompt_resume(current_session_id, history)
+                continue
+            if command == "/model":
+                prompt_model()
+                continue
+
+            msg_queue.put(query)
+
+    msg_queue.put(None)
+    worker.join(timeout=5)

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -1,164 +1,79 @@
-import queue
-import threading
-import time
-import uuid
-from contextlib import suppress
-
-from anthropic.types import MessageParam
-from prompt_toolkit import PromptSession
-from prompt_toolkit.formatted_text import HTML, FormattedText
-from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 from prompt_toolkit.patch_stdout import patch_stdout
 
-from ..agent.agent import agent_loop
-from .display import (
-    COMPLETION_STYLE,
-    LIGHT_HINT_STYLE,
-    CommandCompleter,
-    clear_terminal,
-    print_welcome_banner,
-)
-from .display.printing import get_status_toolbar
-from .display.theme import PROMPT_ACCENT_COLOR
+from .display import clear_terminal, print_welcome_banner
 from .models import prompt_model
-from .sessions import prompt_resume, save_session_history
+from .prompting import SessionSignal, build_session
+from .runtime import BackgroundAgentRunner, ConversationState, new_session_id
+from .sessions import prompt_resume
 
 
-def build_session(
-    agent_running: threading.Event,
-    cancel: threading.Event,
-) -> tuple[PromptSession, object]:
-    bindings = KeyBindings()
-    last_ctrl_c = 0.0
-    hint_refresh_timer: threading.Timer | None = None
-    exit_sentinel = object()
-    ctrl_c_timeout = 1.0
-    _hint_text = FormattedText([(LIGHT_HINT_STYLE, "  Press Ctrl-C again to exit")])
+def should_defer_session_command(
+    command: str,
+    runner: BackgroundAgentRunner,
+) -> bool:
+    if not runner.is_busy():
+        return False
 
-    def status_toolbar() -> FormattedText:
-        if time.monotonic() < last_ctrl_c + ctrl_c_timeout:
-            return _hint_text
-        return get_status_toolbar()
-
-    @bindings.add("c-c")
-    def clear_buffer(event: KeyPressEvent) -> None:
-        nonlocal last_ctrl_c, hint_refresh_timer
-
-        if agent_running.is_set():
-            cancel.set()
-            return
-
-        now = time.monotonic()
-        if now - last_ctrl_c <= ctrl_c_timeout:
-            if hint_refresh_timer is not None:
-                hint_refresh_timer.cancel()
-            event.app.exit(result=exit_sentinel)
-            return
-
-        last_ctrl_c = now
-        event.current_buffer.reset()
-        event.app.invalidate()
-
-        if hint_refresh_timer is not None:
-            hint_refresh_timer.cancel()
-
-        hint_refresh_timer = threading.Timer(ctrl_c_timeout, event.app.invalidate)
-        hint_refresh_timer.daemon = True
-        hint_refresh_timer.start()
-
-    @bindings.add("enter")
-    def submit(event: KeyPressEvent) -> None:
-        event.current_buffer.validate_and_handle()
-
-    @bindings.add("escape", "enter")
-    def insert_newline(event: KeyPressEvent) -> None:
-        event.current_buffer.insert_text("\n")
-
-    return (
-        PromptSession(
-            HTML(f'<style color="{PROMPT_ACCENT_COLOR}">> </style>'),
-            multiline=True,
-            key_bindings=bindings,
-            completer=CommandCompleter(),
-            complete_while_typing=True,
-            style=COMPLETION_STYLE,
-            bottom_toolbar=status_toolbar,
-            reserve_space_for_menu=2,
-        ),
-        exit_sentinel,
-    )
+    print(f"Interrupt queued or running work before using {command}.\n")
+    return True
 
 
 def main() -> None:
     print_welcome_banner()
-    history: list[MessageParam] = []
-    current_session_id = uuid.uuid4().hex
-    agent_running = threading.Event()
-    cancel = threading.Event()
-    session, exit_sentinel = build_session(agent_running, cancel)
-    msg_queue: queue.Queue[str | None] = queue.Queue()
+    conversation = ConversationState()
+    runner = BackgroundAgentRunner(conversation)
+    session, ctrl_c_behavior = build_session(
+        agent_running=runner.running_event,
+        cancel=runner.cancel_event,
+    )
+    runner.attach_session(session)
+    runner.start()
 
-    def agent_worker() -> None:
-        nonlocal current_session_id
-        while True:
-            query = msg_queue.get()
-            if query is None:
-                break
+    try:
+        with patch_stdout(raw=True):
+            while True:
+                try:
+                    query = session.prompt()
+                    print()
+                except KeyboardInterrupt:
+                    continue
+                except EOFError:
+                    break
 
-            agent_running.set()
-            with suppress(Exception):
-                session.app.invalidate()
+                if query is SessionSignal.EXIT:
+                    break
 
-            history.append({"role": "user", "content": query})
-            history_len = len(history)
-            agent_loop(history, cancel=cancel)
-            cancel.clear()
+                command = query.strip().lower()
+                if command in {"", "q", "exit"}:
+                    break
+                if command == "/new":
+                    if should_defer_session_command(command, runner):
+                        continue
 
-            if len(history) > history_len:
-                save_session_history(current_session_id, history)
-                response_content = history[-1]["content"]
-                if isinstance(response_content, list):
-                    for block in response_content:
-                        if hasattr(block, "text"):
-                            print(f"> {block.text}\n")
+                    conversation.history.clear()
+                    conversation.session_id = new_session_id()
+                    clear_terminal()
+                    continue
+                if command == "/resume":
+                    if should_defer_session_command(command, runner):
+                        continue
 
-            agent_running.clear()
-            with suppress(Exception):
-                session.app.invalidate()
+                    (
+                        conversation.session_id,
+                        conversation.history,
+                    ) = prompt_resume(
+                        conversation.session_id,
+                        conversation.history,
+                    )
+                    continue
+                if command == "/model":
+                    if should_defer_session_command(command, runner):
+                        continue
 
-    worker = threading.Thread(target=agent_worker, daemon=True)
-    worker.start()
+                    prompt_model()
+                    continue
 
-    with patch_stdout(raw=True):
-        while True:
-            try:
-                query = session.prompt()
-                print()
-            except KeyboardInterrupt:
-                continue
-            except EOFError:
-                break
-
-            if query is exit_sentinel:
-                break
-
-            command = query.strip().lower()
-            if command in {"", "q", "exit"}:
-                break
-            if command == "/new":
-                history.clear()
-                current_session_id = uuid.uuid4().hex
-                clear_terminal()
-                continue
-            if command == "/resume":
-                current_session_id, history = prompt_resume(current_session_id, history)
-                continue
-            if command == "/model":
-                prompt_model()
-                continue
-
-            msg_queue.put(query)
-
-    msg_queue.put(None)
-    worker.join(timeout=5)
+                runner.submit(query)
+    finally:
+        ctrl_c_behavior.dispose()
+        runner.stop()

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -1,14 +1,17 @@
+import threading
+import time
 import uuid
 
 from anthropic.types import MessageParam
 from prompt_toolkit import PromptSession
-from prompt_toolkit.formatted_text import HTML
+from prompt_toolkit.formatted_text import HTML, FormattedText
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 
 from ..agent.agent import agent_loop
 from .display import (
     COMPLETION_STYLE,
+    LIGHT_HINT_STYLE,
     CommandCompleter,
     clear_terminal,
     print_welcome_banner,
@@ -19,12 +22,40 @@ from .models import prompt_model
 from .sessions import prompt_resume, save_session_history
 
 
-def build_session() -> PromptSession:
+def build_session() -> tuple[PromptSession, object]:
     bindings = KeyBindings()
+    last_ctrl_c = 0.0
+    hint_refresh_timer: threading.Timer | None = None
+    exit_sentinel = object()
+    ctrl_c_timeout = 1.0
+    _hint_text = FormattedText([(LIGHT_HINT_STYLE, "  Press Ctrl-C again to exit")])
+
+    def status_toolbar() -> FormattedText:
+        if time.monotonic() < last_ctrl_c + ctrl_c_timeout:
+            return _hint_text
+        return get_status_toolbar()
 
     @bindings.add("c-c")
     def clear_buffer(event: KeyPressEvent) -> None:
+        nonlocal last_ctrl_c, hint_refresh_timer
+
+        now = time.monotonic()
+        if now - last_ctrl_c <= ctrl_c_timeout:
+            if hint_refresh_timer is not None:
+                hint_refresh_timer.cancel()
+            event.app.exit(result=exit_sentinel)
+            return
+
+        last_ctrl_c = now
         event.current_buffer.reset()
+        event.app.invalidate()
+
+        if hint_refresh_timer is not None:
+            hint_refresh_timer.cancel()
+
+        hint_refresh_timer = threading.Timer(ctrl_c_timeout, event.app.invalidate)
+        hint_refresh_timer.daemon = True
+        hint_refresh_timer.start()
 
     @bindings.add("enter")
     def submit(event: KeyPressEvent) -> None:
@@ -34,14 +65,17 @@ def build_session() -> PromptSession:
     def insert_newline(event: KeyPressEvent) -> None:
         event.current_buffer.insert_text("\n")
 
-    return PromptSession(
-        HTML(f'<style color="{PROMPT_ACCENT_COLOR}">> </style>'),
-        multiline=True,
-        key_bindings=bindings,
-        completer=CommandCompleter(),
-        complete_while_typing=True,
-        style=COMPLETION_STYLE,
-        bottom_toolbar=get_status_toolbar,
+    return (
+        PromptSession(
+            HTML(f'<style color="{PROMPT_ACCENT_COLOR}">> </style>'),
+            multiline=True,
+            key_bindings=bindings,
+            completer=CommandCompleter(),
+            complete_while_typing=True,
+            style=COMPLETION_STYLE,
+            bottom_toolbar=status_toolbar,
+        ),
+        exit_sentinel,
     )
 
 
@@ -49,7 +83,7 @@ def main() -> None:
     print_welcome_banner()
     history: list[MessageParam] = []
     current_session_id = uuid.uuid4().hex
-    session = build_session()
+    session, exit_sentinel = build_session()
 
     while True:
         try:
@@ -58,6 +92,9 @@ def main() -> None:
         except KeyboardInterrupt:
             continue
         except EOFError:
+            break
+
+        if query is exit_sentinel:
             break
 
         command = query.strip().lower()

--- a/src/mini_agent/cli/prompting.py
+++ b/src/mini_agent/cli/prompting.py
@@ -1,0 +1,101 @@
+import threading
+import time
+from enum import Enum, auto
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.formatted_text import HTML, FormattedText
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+
+from .display import COMPLETION_STYLE, LIGHT_HINT_STYLE, CommandCompleter
+from .display.printing import get_status_toolbar
+from .display.theme import PROMPT_ACCENT_COLOR
+
+
+class SessionSignal(Enum):
+    EXIT = auto()
+
+
+class CtrlCBehavior:
+    def __init__(
+        self,
+        agent_running: threading.Event,
+        cancel: threading.Event,
+        timeout_seconds: float = 1.0,
+    ) -> None:
+        self._agent_running = agent_running
+        self._cancel = cancel
+        self._timeout_seconds = timeout_seconds
+        self._last_press_at = 0.0
+        self._hint_refresh_timer: threading.Timer | None = None
+        self._hint_text = FormattedText(
+            [(LIGHT_HINT_STYLE, "  Press Ctrl-C again to exit")]
+        )
+
+    def bottom_toolbar(self) -> FormattedText:
+        if time.monotonic() < self._last_press_at + self._timeout_seconds:
+            return self._hint_text
+        return get_status_toolbar()
+
+    def handle(self, event: KeyPressEvent) -> None:
+        if self._agent_running.is_set():
+            self._cancel.set()
+            return
+
+        now = time.monotonic()
+        if now - self._last_press_at <= self._timeout_seconds:
+            self.dispose()
+            event.app.exit(result=SessionSignal.EXIT)
+            return
+
+        self._last_press_at = now
+        event.current_buffer.reset()
+        event.app.invalidate()
+        self._schedule_hint_refresh(event)
+
+    def dispose(self) -> None:
+        if self._hint_refresh_timer is None:
+            return
+        self._hint_refresh_timer.cancel()
+        self._hint_refresh_timer = None
+
+    def _schedule_hint_refresh(self, event: KeyPressEvent) -> None:
+        self.dispose()
+        self._hint_refresh_timer = threading.Timer(
+            self._timeout_seconds,
+            event.app.invalidate,
+        )
+        self._hint_refresh_timer.daemon = True
+        self._hint_refresh_timer.start()
+
+
+def build_session(
+    agent_running: threading.Event,
+    cancel: threading.Event,
+) -> tuple[PromptSession, CtrlCBehavior]:
+    bindings = KeyBindings()
+    ctrl_c_behavior = CtrlCBehavior(agent_running, cancel)
+
+    @bindings.add("c-c")
+    def handle_ctrl_c(event: KeyPressEvent) -> None:
+        ctrl_c_behavior.handle(event)
+
+    @bindings.add("enter")
+    def submit(event: KeyPressEvent) -> None:
+        event.current_buffer.validate_and_handle()
+
+    @bindings.add("escape", "enter")
+    def insert_newline(event: KeyPressEvent) -> None:
+        event.current_buffer.insert_text("\n")
+
+    session = PromptSession(
+        HTML(f'<style color="{PROMPT_ACCENT_COLOR}">> </style>'),
+        multiline=True,
+        key_bindings=bindings,
+        completer=CommandCompleter(),
+        complete_while_typing=True,
+        style=COMPLETION_STYLE,
+        bottom_toolbar=ctrl_c_behavior.bottom_toolbar,
+        reserve_space_for_menu=3,
+    )
+    return session, ctrl_c_behavior

--- a/src/mini_agent/cli/runtime.py
+++ b/src/mini_agent/cli/runtime.py
@@ -1,0 +1,128 @@
+import queue
+import threading
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass, field
+
+from anthropic.types import MessageParam
+from prompt_toolkit import PromptSession
+
+from ..agent.agent import agent_loop
+from .sessions import save_session_history
+
+
+def new_session_id() -> str:
+    return uuid.uuid4().hex
+
+
+@dataclass(slots=True)
+class ConversationState:
+    history: list[MessageParam] = field(default_factory=list)
+    session_id: str = field(default_factory=new_session_id)
+
+
+class BackgroundAgentRunner:
+    def __init__(self, conversation: ConversationState) -> None:
+        self._session: PromptSession | None = None
+        self._conversation = conversation
+        self._running = threading.Event()
+        self._cancel = threading.Event()
+        self._queue: queue.Queue[str | None] = queue.Queue()
+        self._pending_requests = 0
+        self._pending_lock = threading.Lock()
+        self._worker: threading.Thread | None = None
+
+    @property
+    def running_event(self) -> threading.Event:
+        return self._running
+
+    @property
+    def cancel_event(self) -> threading.Event:
+        return self._cancel
+
+    def submit(self, query: str) -> None:
+        with self._pending_lock:
+            self._pending_requests += 1
+        self._queue.put(query)
+
+    def attach_session(self, session: PromptSession) -> None:
+        self._session = session
+
+    def start(self) -> None:
+        if self._worker is not None:
+            return
+
+        self._worker = threading.Thread(target=self._agent_worker, daemon=True)
+        self._worker.start()
+
+    def interrupt(self) -> None:
+        self._cancel.set()
+
+    def is_busy(self) -> bool:
+        with self._pending_lock:
+            return self._pending_requests > 0
+
+    def stop(self, timeout: float = 5.0) -> None:
+        if self._worker is None:
+            return
+
+        self._cancel.set()
+        self._drain_queue()
+        self._queue.put(None)
+        self._worker.join(timeout=timeout)
+
+    def _agent_worker(self) -> None:
+        while True:
+            query = self._queue.get()
+            if query is None:
+                break
+
+            self._running.set()
+            self._invalidate_session()
+
+            try:
+                history = self._conversation.history
+                history.append({"role": "user", "content": query})
+                history_len = len(history)
+                agent_loop(history, cancel=self._cancel)
+                self._cancel.clear()
+
+                if len(history) > history_len:
+                    save_session_history(self._conversation.session_id, history)
+                    self._print_response(history[-1]["content"])
+            except Exception as e:
+                print(f"Error: {e}\n")
+            finally:
+                self._cancel.clear()
+                self._running.clear()
+                self._mark_request_complete()
+                self._invalidate_session()
+
+    def _drain_queue(self) -> None:
+        while True:
+            try:
+                query = self._queue.get_nowait()
+            except queue.Empty:
+                return
+
+            if query is not None:
+                self._mark_request_complete()
+
+    def _mark_request_complete(self) -> None:
+        with self._pending_lock:
+            self._pending_requests = max(self._pending_requests - 1, 0)
+
+    def _invalidate_session(self) -> None:
+        if self._session is None:
+            return
+        with suppress(Exception):
+            self._session.app.invalidate()
+
+    @staticmethod
+    def _print_response(content: object) -> None:
+        if not isinstance(content, list):
+            return
+
+        for block in content:
+            if hasattr(block, "text"):
+                print(f"> {block.text}\n")


### PR DESCRIPTION
## Summary
- run the agent loop on a worker thread so the prompt stays available
- add a Ctrl-C hint and double-press exit behavior in the CLI
- support interrupting in-flight agent runs and canceling cleanly

## Notes
- The PR includes the last 3 commits on the feature branch

## Testing
- not run (not requested)
