### PR TITLE
refactor(config): replace module globals with Config class singleton

### DIFF
--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from ..cli.display import print_tool_result
 from ..cli.models import get_max_output_tokens
 from ..cli.token import token_tracker
-from ..config import WORKDIR, client, get_model
+from ..config import WORKDIR, client, config
 from .skills import skill_loader
 from .tools import TOOL_HANDLERS, TOOLS
 
@@ -32,7 +32,7 @@ Available skills:
 
 def agent_loop(messages: list[MessageParam]) -> None:
     rounds_since_todo = 0
-    model = get_model()
+    model = config.get_model()
     max_tokens = get_max_output_tokens(model) or 1024
 
     while True:

--- a/src/mini_agent/cli/display/printing.py
+++ b/src/mini_agent/cli/display/printing.py
@@ -8,7 +8,7 @@ from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.shortcuts import print_formatted_text
 
 from ...agent.tools import safe_path
-from ...config import CLI_NAME, CLI_VERSION, get_model
+from ...config import CLI_NAME, CLI_VERSION, config
 from .diff import format_edit_diff
 from .theme import LIGHT_TEXT, PROMPT_ACCENT_COLOR, RESET
 
@@ -25,7 +25,7 @@ def print_welcome_banner() -> None:
     lines = [
         f" >_ {CLI_NAME} (v{CLI_VERSION})",
         "",
-        f" model: {get_model()}",
+        f" model: {config.get_model()}",
     ]
     width = max(len(line) for line in lines)
 

--- a/src/mini_agent/cli/display/toolbar.py
+++ b/src/mini_agent/cli/display/toolbar.py
@@ -2,7 +2,7 @@ import shutil
 
 from prompt_toolkit.formatted_text import FormattedText
 
-from ...config import get_model
+from ...config import config
 from ..models import get_max_context_tokens
 from ..token import token_tracker
 from .picker import LIGHT_HINT_STYLE
@@ -12,7 +12,7 @@ def _format_token_right(
     total: tuple[int, int], last_round: tuple[int, int] | None
 ) -> str:
     right = f"↑{total[0]} ↓{total[1]}"
-    context_limit = get_max_context_tokens(get_model())
+    context_limit = get_max_context_tokens(config.get_model())
     if context_limit and last_round is not None:
         used_tokens = last_round[0] + last_round[1]
         percent = min(100.0, (used_tokens / context_limit) * 100)
@@ -27,7 +27,7 @@ def _pad_toolbar(left: str, right: str) -> str:
 
 
 def get_status_toolbar() -> FormattedText:
-    left = f"  {get_model()}"
+    left = f"  {config.get_model()}"
     usage = token_tracker.get()
     if usage is not None:
         right = _format_token_right(usage, token_tracker.get_last_round())

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -8,7 +8,7 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 
 from ..agent.agent import agent_loop
-from ..config import set_session_model
+from ..config import config
 from .display import (
     COMPLETION_STYLE,
     CommandCompleter,
@@ -59,7 +59,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.model:
-        set_session_model(args.model)
+        config.set_session_model(args.model)
 
     print_welcome_banner()
     history: list[MessageParam] = []

--- a/src/mini_agent/cli/models.py
+++ b/src/mini_agent/cli/models.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 
 from anthropic.types import ModelInfo
 
-from ..config import client, get_model, save_model
+from ..config import client, config
 from .display.picker import select_from_list
 
 
@@ -72,7 +72,7 @@ def format_model(model: ModelInfo) -> str:
 
 
 def select_model(models: list[ModelInfo]) -> ModelInfo | None:
-    current = get_model()
+    current = config.get_model()
     ids = [m.id for m in models]
     selected_index = ids.index(current) if current in ids else 0
     return select_from_list(
@@ -97,5 +97,5 @@ def prompt_model() -> None:
     if result is None:
         return
 
-    save_model(result.id)
+    config.save_model(result.id)
     print(f"Model set to {result.id}\n")

--- a/src/mini_agent/config.py
+++ b/src/mini_agent/config.py
@@ -25,15 +25,6 @@ if os.getenv("ANTHROPIC_BASE_URL"):
 
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 
-_model: str | None = None
-_session_model_override: str | None = None
-
-
-def set_session_model(model_id: str | None) -> None:
-    """Set a model override for the current session only."""
-    global _session_model_override
-    _session_model_override = model_id
-
 
 def _load_config() -> dict[str, object]:
     if CONFIG_FILE.exists():
@@ -41,24 +32,32 @@ def _load_config() -> dict[str, object]:
     return {}
 
 
-def get_model() -> str:
-    global _model
-    if _session_model_override is not None:
-        return _session_model_override
-    if _model is None:
-        config = _load_config()
-        _model = str(config.get("model_id", DEFAULT_MODEL))
-    return _model
+class Config:
+    def __init__(self) -> None:
+        self._model: str | None = None
+        self._session_model_override: str | None = None
+
+    def set_session_model(self, model_id: str) -> None:
+        self._session_model_override = model_id
+
+    def get_model(self) -> str:
+        if self._session_model_override is not None:
+            return self._session_model_override
+        if self._model is None:
+            cfg = _load_config()
+            self._model = str(cfg.get("model_id", DEFAULT_MODEL))
+        return self._model
+
+    def save_model(self, model_id: str) -> None:
+        self._session_model_override = None
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        cfg = _load_config()
+        cfg["model_id"] = model_id
+        CONFIG_FILE.write_text(tomli_w.dumps(cfg))
+        self._model = model_id
 
 
-def save_model(model_id: str) -> None:
-    global _model, _session_model_override
-    _session_model_override = None
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    config = _load_config()
-    config["model_id"] = model_id
-    CONFIG_FILE.write_text(tomli_w.dumps(config))
-    _model = model_id
+config = Config()
 
 
 CLI_NAME = "mini-agent"


### PR DESCRIPTION
Replace the `_model` and `_session_model_override` module-level globals and their associated free functions (`get_model`, `save_model`, `set_session_model`) with a `Config` class. A module-level `config` singleton is exposed for all call sites.

- Eliminates `global` statements and implicit shared mutable state
- Makes config state independently instantiable and testable
- All callers updated to use `config.get_model()`, `config.save_model()`, `config.set_session_model()`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kowyo/mini-agent/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
