### PR TITLE
feat(cli): add -p/--prompt argument for non-interactive execution

### DIFF
--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -1,11 +1,13 @@
 import argparse
 import uuid
+from html import escape
 
 from anthropic.types import MessageParam
 from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+from prompt_toolkit.shortcuts import print_formatted_text
 
 from ..agent.agent import agent_loop
 from ..config import config
@@ -66,6 +68,9 @@ def _run_interactive(prompt: str | None = None) -> None:
     session = build_session()
 
     if prompt is not None:
+        print_formatted_text(
+            HTML(f'<style color="{PROMPT_ACCENT_COLOR}">&gt; </style>{escape(prompt)}')
+        )
         print()
         history.append({"role": "user", "content": prompt})
         history_len = len(history)


### PR DESCRIPTION
Closes #15

## Description

This PR adds two ways to run mini-agent with a prompt:

### 1. Non-interactive mode (`-p`/`--prompt`)
Run a single prompt and exit - useful for scripting and piping:

```bash
# Run a single prompt and exit
mini-agent -p "Summarize the README"

# Pipe content from a file
mini-agent -p "$(cat error.log)"
```

### 2. Interactive mode with initial prompt (positional argument)
Start an interactive session with an initial prompt already sent:

```bash
# Start interactive session with initial prompt
mini-agent "Summarize the README"

# This enters the TUI and shows the response, then waits for follow-up questions
```

### Changes

- Added `-p`/`--prompt` argument for non-interactive execution
- Added positional `initial_prompt` argument for interactive mode with startup prompt
- Created `_run_non_interactive()` function for single-shot execution
- Modified `_run_interactive()` to accept optional initial prompt
- Maintains backward compatibility - running `mini-agent` without args still starts TUI

## Testing

- Verified `mini-agent --help` shows both options
- Ruff checks pass
- No breaking changes to existing functionality

## Usage Examples Summary

```bash
# Interactive TUI (default)
mini-agent

# Interactive with initial prompt
mini-agent "List Python files"

# Non-interactive (single shot)
mini-agent -p "List Python files"
mini-agent --prompt "List Python files"
```
