### PR TITLE
feat(cli): auto-submit initial prompt via pre_run callback

### DIFF
--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -84,7 +84,7 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
     print_welcome_banner()
     history: list[MessageParam] = []
     current_session_id = uuid.uuid4().hex
-    session, _pre_run = build_session(prompt)
+    session, pre_run = build_session(prompt)
 
     if session_id is not None:
         current_session_id = session_id
@@ -102,8 +102,8 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
 
     while True:
         try:
-            query = session.prompt(pre_run=_pre_run)
-            _pre_run = None
+            query = session.prompt(pre_run=pre_run)
+            pre_run = None
             print()
         except KeyboardInterrupt:
             continue


### PR DESCRIPTION
Pass the initial prompt to `build_session()`, which returns a `pre_run` callback alongside the session. The callback pre-fills the buffer and immediately submits it on the first interactive prompt call, letting the initial prompt flow naturally through the main loop — including after `--resume` loads history.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kowyo/mini-agent/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
