### PR TITLE
feat(cli): allow manual model ID entry when selecting models

### DIFF
--- a/src/mini_agent/cli/models.py
+++ b/src/mini_agent/cli/models.py
@@ -71,17 +71,29 @@ def format_model(model: ModelInfo) -> str:
     return "  ".join(parts)
 
 
-def select_model(models: list[ModelInfo]) -> ModelInfo | None:
+_ENTER_MANUALLY = "Enter model ID manually..."
+
+
+def select_model(models: list[ModelInfo]) -> str | None:
     current = config.get_model()
     ids = [m.id for m in models]
     selected_index = ids.index(current) if current in ids else 0
-    return select_from_list(
-        models,
-        "Select model",
-        format_model,
-        selected_index=selected_index,
-        clear_after=True,
+
+    items: list[ModelInfo | str] = [*models, _ENTER_MANUALLY]
+
+    def fmt(item: ModelInfo | str) -> str:
+        return item if isinstance(item, str) else format_model(item)
+
+    result = select_from_list(
+        items, "Select model", fmt, selected_index=selected_index, clear_after=True
     )
+    if result is None:
+        return None
+    if isinstance(result, str):
+        model_id = input("Model ID: ").strip()
+        print("\033[1A\033[2K", end="", flush=True)
+        return model_id or None
+    return result.id
 
 
 def select_reasoning_effort() -> str | None:
@@ -107,12 +119,22 @@ def prompt_model() -> None:
         return
 
     if not models:
-        print("No models available.\n")
+        print("No models available from API. Enter a model ID manually.")
+        model_id = input("Model ID: ").strip()
+        if not model_id:
+            return
+        effort_result = select_reasoning_effort()
+        if effort_result is None:
+            return
+        config.save_model(model_id)
+        config.save_reasoning_effort(effort_result)
+        effort = config.get_reasoning_effort()
+        print(f"Model set to {model_id} {effort}\n")
         return
 
-    model_result = select_model(models)
+    model_id = select_model(models)
 
-    if model_result is None:
+    if model_id is None:
         return
 
     effort_result = select_reasoning_effort()
@@ -120,7 +142,7 @@ def prompt_model() -> None:
     if effort_result is None:
         return
 
-    config.save_model(model_result.id)
+    config.save_model(model_id)
     config.save_reasoning_effort(effort_result)
     effort = config.get_reasoning_effort()
-    print(f"Model set to {model_result.id} {effort}\n")
+    print(f"Model set to {model_id} {effort}\n")


### PR DESCRIPTION
## Description

This PR adds the ability to manually enter a model ID when selecting models in the CLI. This is useful when:

- No models are available from the API (e.g., API key issues, network problems)
- The user wants to use a model not listed by the provider's API

## Changes

- Added "Enter model ID manually..." option to the model selection list
- Modified "No models available" message to prompt for manual entry
- Updated `select_model()` to return a string (model ID) instead of ModelInfo
- Allows users to type a custom model ID directly

## Test

- Tested with empty model list scenario
- Tested manual entry flow from the selection menu
- Verified the model ID is properly saved to config

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kowyo/mini-agent/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
