### PR TITLE
feat(tools): allow /tmp/ directory and its subdirs in safe_path

### DIFF
--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -9,10 +9,13 @@ from .skills import skill_loader
 
 
 def safe_path(path_str: str) -> Path:
-    path = (WORKDIR / path_str).resolve()
-    if not path.is_relative_to(WORKDIR):
-        raise ValueError(f"Path escapes workspace: {path_str}")
-    return path
+    path = Path(path_str)
+    path = path.resolve() if path.is_absolute() else (WORKDIR / path_str).resolve()
+
+    if path.is_relative_to(WORKDIR) or path.is_relative_to(Path("/tmp")):
+        return path
+
+    raise ValueError(f"Path escapes workspace: {path_str}")
 
 
 def run_bash(command: str) -> str:


### PR DESCRIPTION
## Description

Extends the `safe_path()` function to allow access to `/tmp/` directory and its subdirectories, in addition to the existing `WORKDIR` restriction.

### Changes
- Modified `safe_path()` to accept paths within `/tmp/` hierarchy
- Maintains backward compatibility with relative paths (resolved against `WORKDIR`)
- Absolute paths are checked against both `WORKDIR` and `/tmp/` allowlists

### Motivation
This enables the agent to read and write temporary files in `/tmp/`, which is useful for:
- Creating temporary working files during tool execution
- Processing files that shouldn't persist in the project directory
- Writing PR bodies and other temporary content to `/tmp/`

### Code Changes
```python
def safe_path(path_str: str) -> Path:
    path = Path(path_str)
    
    # If absolute path, check directly; otherwise resolve relative to WORKDIR
    path = path.resolve() if path.is_absolute() else (WORKDIR / path_str).resolve()
    
    # Check if path is within WORKDIR
    if path.is_relative_to(WORKDIR):
        return path
    
    # Check if path is within /tmp/
    if path.is_relative_to(Path("/tmp")):
        return path
    
    raise ValueError(f"Path escapes workspace: {path_str}")
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kowyo/mini-agent/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
