### PR TITLE
refactor(cli): replace argparse with typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,13 @@ readme = "README.md"
 requires-python = ">=3.14"
 authors = [{ name = "Kowyo", email = "kowyo@outlook.com" }]
 dependencies = [
-    "anthropic>=0.88.0",
+    "anthropic>=0.89.0",
     "prompt-toolkit>=3.0.52",
     "python-dotenv>=1.2.2",
     "pyyaml>=6.0.3",
     "rich>=14.3.3",
     "tomli-w>=1.2.0",
+    "typer>=0.24.1",
 ]
 
 [dependency-groups]
@@ -19,7 +20,7 @@ dev = [
     "commitizen>=4.8.3",
     "prek>=0.3.8",
     "ruff>=0.15.9",
-    "ty>=0.0.28",
+    "ty>=0.0.29",
 ]
 
 [project.scripts]

--- a/src/mini_agent/__init__.py
+++ b/src/mini_agent/__init__.py
@@ -1,3 +1,5 @@
-from .cli.main import main
+from .cli.main import app
 
-__all__ = ["main"]
+main = app
+
+__all__ = ["main", "app"]

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -1,8 +1,9 @@
-import argparse
+import sys
 import uuid
 from collections.abc import Callable
-from importlib.metadata import version
+from typing import Annotated
 
+import click
 from anthropic.types import MessageParam
 from prompt_toolkit import PromptSession
 from prompt_toolkit.application import get_app
@@ -10,9 +11,10 @@ from prompt_toolkit.document import Document
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+from typer import Argument, Exit, Option, Typer
 
 from ..agent.agent import agent_loop
-from ..config import REASONING_EFFORT_LEVELS, config
+from ..config import CLI_NAME, CLI_VERSION, REASONING_EFFORT_LEVELS, config
 from .display import (
     COMPLETION_STYLE,
     CommandCompleter,
@@ -30,6 +32,28 @@ from .sessions import (
     session_saved,
 )
 from .token import token_tracker
+
+
+def _fix_resume_args() -> None:
+    """Fix -r/--resume args to support optional value (nargs='?' behavior)."""
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg in ("-r", "--resume") and (
+            i + 1 >= len(args) or args[i + 1].startswith("-")
+        ):
+            # Insert __LATEST__ after -r/--resume when no value provided
+            sys.argv.insert(i + 2, "__LATEST__")
+            break
+
+
+# Apply fix before Typer parses arguments
+_fix_resume_args()
+
+app = Typer(
+    help="A minimal agent.",
+    context_settings={"help_option_names": ["-h", "--help"]},
+    add_completion=False,
+)
 
 
 def build_session(
@@ -141,68 +165,70 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
         print(f"\nResume the session with:\nmini-agent --resume {current_session_id}\n")
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="A minimal agent.")
-    parser.add_argument(
-        "-v",
-        "--version",
-        action="version",
-        version=f"%(prog)s {version('mini-agent')}",
-    )
-    parser.add_argument(
-        "-m",
-        "--model",
-        type=str,
-        help="Model for the current session",
-    )
-    parser.add_argument(
-        "-e",
-        "--effort",
-        type=str,
-        choices=REASONING_EFFORT_LEVELS,
-        help="Set the effort level for the current session",
-    )
-    parser.add_argument(
-        "-p",
-        "--print",
-        dest="print_prompt",
-        type=str,
-        help="Print response without interactive mode",
-    )
-    parser.add_argument(
-        "-r",
-        "--resume",
-        dest="session_id",
-        nargs="?",
-        const="__LATEST__",
-        type=str,
-        help="Resume a session by ID, or resume the most recent session if no ID provided",
-    )
-    parser.add_argument(
-        "prompt",
-        nargs="?",
-        type=str,
-        help="Start interactive session with initial prompt",
-    )
-    args = parser.parse_args()
+def version_callback(value: bool) -> None:
+    if value:
+        print(f"{CLI_NAME} {CLI_VERSION}")
+        raise Exit(0)
 
-    if args.model:
-        config.set_session_model(args.model)
 
-    if args.effort:
-        config.set_session_reasoning_effort(args.effort)
+@app.callback(invoke_without_command=True)
+def main(
+    prompt: Annotated[
+        str | None, Argument(help="Start interactive session with initial prompt")
+    ] = None,
+    version: Annotated[
+        bool,
+        Option(
+            "-v",
+            "--version",
+            help="Show version",
+            callback=version_callback,
+            is_eager=True,
+        ),
+    ] = False,
+    model: Annotated[
+        str | None, Option("-m", "--model", help="Model for the current session")
+    ] = None,
+    effort: Annotated[
+        str | None,
+        Option(
+            "-e",
+            "--effort",
+            help="Set the effort level for the current session",
+            click_type=click.Choice(REASONING_EFFORT_LEVELS),
+        ),
+    ] = None,
+    print_prompt: Annotated[
+        str | None,
+        Option("-p", "--print", help="Print response without interactive mode"),
+    ] = None,
+    resume: Annotated[
+        str | None,
+        Option(
+            "-r",
+            "--resume",
+            help="Resume a session by ID, or resume the most recent session if no ID provided",
+        ),
+    ] = None,
+) -> None:
+    """A minimal agent."""
+    if model:
+        config.set_session_model(model)
 
-    if args.print_prompt:
-        _run_non_interactive(args.print_prompt)
+    if effort:
+        config.set_session_reasoning_effort(effort)
+
+    if print_prompt:
+        _run_non_interactive(print_prompt)
         return
 
-    session_id: str | None = args.session_id
+    session_id = resume
     if session_id == "__LATEST__":
         sessions = list_sessions()
         if sessions:
             session_id = sessions[0].session_id
         else:
             print("No saved sessions found.")
-            return
+            raise Exit(1)
 
-    _run_interactive(args.prompt, session_id)
+    _run_interactive(prompt, session_id)


### PR DESCRIPTION
Replace argparse with Typer for type-safe CLI.

Changes:
- Use Typer instead of argparse for CLI framework
- Richer help output with formatted tables
- Add typer>=0.24.1 dependency
- Use click.Choice for automatic effort level validation
- Use typer.Exit for clean CLI exits
- Work around Typer limitation to preserve -r/--resume optional value behavior

All original functionality preserved: --version, --model, --effort, --print, --resume (with optional value), [PROMPT].