### PR TITLE
feat: add image input support with Ctrl+V paste

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.14"
 authors = [{ name = "Kowyo", email = "kowyo@outlook.com" }]
 dependencies = [
     "anthropic>=0.88.0",
+    "pillow>=11.0.0",
     "prompt-toolkit>=3.0.52",
     "python-dotenv>=1.2.2",
     "pyyaml>=6.0.3",

--- a/src/mini_agent/cli/clipboard.py
+++ b/src/mini_agent/cli/clipboard.py
@@ -1,0 +1,103 @@
+"""Clipboard image handling for mini-agent."""
+
+from __future__ import annotations
+
+import base64
+import io
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from PIL.Image import Image
+
+
+def get_clipboard_image() -> Image | None:
+    """Get image from clipboard if available.
+
+    Supports macOS, Linux (with xclip), and Windows.
+    Returns None if no image is available in clipboard.
+    """
+    try:
+        from PIL import ImageGrab
+
+        # Try PIL's grabclipboard first (works on Windows and macOS)
+        img = ImageGrab.grabclipboard()
+        if img is not None:
+            return img
+
+        # Fallback for Linux using xclip
+        if sys.platform == "linux":
+            return _get_linux_clipboard_image()
+
+        return None
+    except ImportError:
+        return None
+    except Exception:
+        return None
+
+
+def _get_linux_clipboard_image() -> Image | None:
+    """Get image from clipboard on Linux using xclip."""
+    try:
+        from PIL import Image
+
+        # Try to get image data from clipboard
+        result = subprocess.run(
+            ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout:
+            return Image.open(io.BytesIO(result.stdout))
+
+        # Try other common formats
+        for img_format in ["image/jpeg", "image/bmp", "image/gif"]:
+            result = subprocess.run(
+                ["xclip", "-selection", "clipboard", "-t", img_format, "-o"],
+                capture_output=True,
+                check=False,
+            )
+            if result.returncode == 0 and result.stdout:
+                return Image.open(io.BytesIO(result.stdout))
+
+        return None
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+
+
+def image_to_base64(img: Image) -> tuple[str, str]:
+    """Convert PIL Image to base64 encoded string.
+
+    Returns:
+        Tuple of (base64_data, media_type)
+    """
+    # Convert to RGB if necessary (for JPEG compatibility)
+    if img.mode in ("RGBA", "P"):
+        img_rgb = img.convert("RGB")
+        buffer = io.BytesIO()
+        img_rgb.save(buffer, format="JPEG")
+        media_type = "image/jpeg"
+    else:
+        buffer = io.BytesIO()
+        img.save(buffer, format="PNG")
+        media_type = "image/png"
+
+    buffer.seek(0)
+    img_bytes = buffer.getvalue()
+    base64_data = base64.b64encode(img_bytes).decode("utf-8")
+
+    return base64_data, media_type
+
+
+def create_image_content_block(img: Image) -> dict:
+    """Create an Anthropic image content block from a PIL Image."""
+    base64_data, media_type = image_to_base64(img)
+    return {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": media_type,
+            "data": base64_data,
+        },
+    }

--- a/src/mini_agent/cli/display/printing.py
+++ b/src/mini_agent/cli/display/printing.py
@@ -40,14 +40,41 @@ def print_welcome_banner() -> None:
     print(f"╰{'─' * (width + 2)}╯\n")
 
 
+def _extract_text_from_content(content: str | list[object]) -> str:
+    """Extract text content from string or multimodal content blocks."""
+    if isinstance(content, str):
+        return content
+
+    texts: list[str] = []
+    image_count = 0
+    for block in content:
+        if isinstance(block, dict):
+            if block.get("type") == "text":
+                text = str(block.get("text", "")).strip()
+                if text:
+                    texts.append(text)
+            elif block.get("type") == "image":
+                image_count += 1
+
+    # Add image indicator if images are present
+    if image_count > 0:
+        indicator = f"📎 {image_count} image{'s' if image_count > 1 else ''}"
+        if texts:
+            texts.append(f"[{indicator}]")
+        else:
+            return f"[{indicator}]"
+
+    return " ".join(texts)
+
+
 def print_session_history(history: list[MessageParam]) -> None:
     clear_terminal()
     print_welcome_banner()
     for message in history:
         content = message["content"]
 
-        if message["role"] == "user" and isinstance(content, str):
-            text = content.strip()
+        if message["role"] == "user":
+            text = _extract_text_from_content(content).strip()
             if text:
                 lines = text.splitlines()
                 print_formatted_text(

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -2,6 +2,7 @@ import argparse
 import uuid
 from collections.abc import Callable
 from importlib.metadata import version
+from typing import Any
 
 from anthropic.types import MessageParam
 from prompt_toolkit import PromptSession
@@ -10,9 +11,11 @@ from prompt_toolkit.document import Document
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+from rich.console import Console
 
 from ..agent.agent import agent_loop
 from ..config import REASONING_EFFORT_LEVELS, config
+from .clipboard import create_image_content_block, get_clipboard_image
 from .display import (
     COMPLETION_STYLE,
     CommandCompleter,
@@ -31,9 +34,12 @@ from .sessions import (
 )
 from .token import token_tracker
 
+console = Console()
+
 
 def build_session(
     prompt: str | None = None,
+    attached_images: list[dict] | None = None,
 ) -> tuple[PromptSession, Callable[[], None] | None]:
     bindings = KeyBindings()
 
@@ -48,6 +54,22 @@ def build_session(
     @bindings.add("escape", "enter")
     def insert_newline(event: KeyPressEvent) -> None:
         event.current_buffer.insert_text("\n")
+
+    @bindings.add("c-v")
+    def paste_image(event: KeyPressEvent) -> None:
+        """Paste image from clipboard."""
+        img = get_clipboard_image()
+        if img is not None:
+            if attached_images is not None:
+                attached_images.append(create_image_content_block(img))
+                # Show feedback that image was attached
+                console.print(
+                    f"[dim]📎 Image attached ({img.width}x{img.height})[/dim]"
+                )
+        else:
+            # No image in clipboard, try normal paste behavior
+            # by letting the default handler process it
+            event.app.clipboard.get_data()
 
     session = PromptSession(
         HTML(f'<style color="{PROMPT_ACCENT_COLOR}">> </style>'),
@@ -70,6 +92,19 @@ def build_session(
     return session, pre_run
 
 
+def create_user_message(query: str, images: list[dict]) -> MessageParam:
+    """Create a user message with optional image content."""
+    if images:
+        # Multimodal message with text and images
+        content: list[dict[str, Any]] = []
+        if query.strip():
+            content.append({"type": "text", "text": query})
+        content.extend(images)
+        return {"role": "user", "content": content}
+    # Text-only message
+    return {"role": "user", "content": query}
+
+
 def _run_non_interactive(prompt: str) -> None:
     """Run the agent on a single prompt and exit (non-interactive mode)."""
     history: list[MessageParam] = [{"role": "user", "content": prompt}]
@@ -85,7 +120,9 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
     print_welcome_banner()
     history: list[MessageParam] = []
     current_session_id = uuid.uuid4().hex
-    session, pre_run = build_session(prompt)
+    # Track images attached via Ctrl+V for the next message
+    attached_images: list[dict] = []
+    session, pre_run = build_session(prompt, attached_images)
 
     if session_id is not None:
         current_session_id = session_id
@@ -118,17 +155,24 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
             history.clear()
             current_session_id = uuid.uuid4().hex
             token_tracker.reset()
+            attached_images.clear()
             clear_terminal()
             print_welcome_banner()
             continue
         if command == "/resume":
             current_session_id, history, _ = prompt_resume(current_session_id, history)
+            attached_images.clear()
             continue
         if command == "/model":
             prompt_model()
             continue
 
-        history.append({"role": "user", "content": query})
+        # Create message with attached images and add to history
+        message = create_user_message(query, attached_images)
+        history.append(message)
+        # Clear attached images after sending
+        attached_images.clear()
+
         history_len = len(history)
         agent_loop(history)
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-04-06T07:14:17.03539Z"
+exclude-newer = "2026-04-13T16:40:58.121904Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -323,6 +323,7 @@ version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "pillow" },
     { name = "prompt-toolkit" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -341,6 +342,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.88.0" },
+    { name = "pillow", specifier = ">=11.0.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -363,6 +365,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR adds image input support with Ctrl+V paste functionality to the mini-agent.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test

Tested locally with image paste via Ctrl+V in the terminal interface.

## Additional

```bash
mini-agent --resume 43d8fff403c8489ca8b40eb09d2eb020
```