### PR TITLE
feat: change CLI command from mini-agent to mini

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
 ]
 
 [project.scripts]
-mini-agent = "mini_agent:main"
+mini = "mini_agent:main"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "C4", "PTH", "ANN", "SIM"]

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -109,7 +109,7 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
         save_session_history(current_session_id, history, token_tracker.get())
 
     if session_saved(current_session_id):
-        print(f"\nResume the session with:\nmini-agent --resume {current_session_id}\n")
+        print(f"\nResume the session with:\nmini --resume {current_session_id}\n")
 
 
 def main() -> None:


### PR DESCRIPTION
## Description

Change the CLI command name from `mini-agent` to `mini` for better user experience and quicker typing.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Changes

- Update CLI entry point in `pyproject.toml` from `mini-agent` to `mini`
- Update resume message in `src/mini_agent/cli/main.py` to reflect new command name

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kowyo/mini-agent/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
