### PR TITLE
refactor!: replace tuple-based token usage with Usage dataclass

### DIFF
--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -12,7 +12,7 @@ from rich.markdown import Markdown
 
 from ..cli.display import LIGHT_HINT_STYLE_RICH, print_tool_result, print_tool_start
 from ..cli.models import get_max_output_tokens
-from ..cli.token import token_tracker
+from ..cli.token import Usage, token_tracker
 from ..config import WORKDIR, client, config
 from .skills import skill_loader
 from .tools import TOOL_HANDLERS, TOOLS
@@ -37,7 +37,7 @@ SYSTEM += (
 
 def agent_loop(messages: list[MessageParam]) -> None:
     model = config.get_model()
-    max_tokens = get_max_output_tokens(model) or 1024
+    max_tokens = get_max_output_tokens(model) or 32768
 
     working_status = None
     thinking_status = None
@@ -98,8 +98,14 @@ def agent_loop(messages: list[MessageParam]) -> None:
             usage = response.usage
             cache_create = getattr(usage, "cache_creation_input_tokens", 0) or 0
             cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
-            total_input_tokens = cache_create + cache_read + usage.input_tokens
-            token_tracker.update(total_input_tokens, usage.output_tokens)
+            token_tracker.update(
+                Usage(
+                    input_tokens=usage.input_tokens,
+                    cache_creation_input_tokens=cache_create,
+                    cache_read_input_tokens=cache_read,
+                    output_tokens=usage.output_tokens,
+                )
+            )
 
             results = []
             for block in response.content:

--- a/src/mini_agent/cli/display/completion.py
+++ b/src/mini_agent/cli/display/completion.py
@@ -13,6 +13,7 @@ COMMANDS = {
     "/new": "Start a new session",
     "/resume": "Resume a previous session",
     "/model": "Select a model",
+    "/status": "Show current session configuration and token usage",
     "/exit": "exit the session",
 }
 

--- a/src/mini_agent/cli/display/toolbar.py
+++ b/src/mini_agent/cli/display/toolbar.py
@@ -9,7 +9,7 @@ from .picker import LIGHT_HINT_STYLE
 
 
 def _format_token_right(total: Usage, last_round: Usage | None) -> str:
-    right = f"in:{total.input_tokens} cre:{total.cache_creation_input_tokens} read:{total.cache_read_input_tokens} ↓{total.output_tokens}"
+    right = f"↑{total.total_input_tokens} ↓{total.output_tokens}"
     context_limit = get_max_context_tokens(config.get_model())
     if context_limit and last_round is not None:
         used_tokens = last_round.total_input_tokens + last_round.output_tokens

--- a/src/mini_agent/cli/display/toolbar.py
+++ b/src/mini_agent/cli/display/toolbar.py
@@ -4,17 +4,15 @@ from prompt_toolkit.formatted_text import FormattedText
 
 from ...config import config
 from ..models import get_max_context_tokens
-from ..token import token_tracker
+from ..token import Usage, token_tracker
 from .picker import LIGHT_HINT_STYLE
 
 
-def _format_token_right(
-    total: tuple[int, int], last_round: tuple[int, int] | None
-) -> str:
-    right = f"↑{total[0]} ↓{total[1]}"
+def _format_token_right(total: Usage, last_round: Usage | None) -> str:
+    right = f"in:{total.input_tokens} cre:{total.cache_creation_input_tokens} read:{total.cache_read_input_tokens} ↓{total.output_tokens}"
     context_limit = get_max_context_tokens(config.get_model())
     if context_limit and last_round is not None:
-        used_tokens = last_round[0] + last_round[1]
+        used_tokens = last_round.total_input_tokens + last_round.output_tokens
         percent = min(100.0, (used_tokens / context_limit) * 100)
         right = f"{right} {percent:.1f}%"
     return f"{right}  "

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -28,6 +28,7 @@ from .sessions import (
     save_session_history,
     session_saved,
 )
+from .status import format_status_report
 from .token import token_tracker
 
 
@@ -98,6 +99,10 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
             continue
         if command == "/model":
             prompt_model()
+            attached_images.clear()
+            continue
+        if command == "/status":
+            print(f"{format_status_report(current_session_id)}\n")
             attached_images.clear()
             continue
 

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -37,8 +37,9 @@ def _run_non_interactive(prompt: str) -> None:
     current_session_id = uuid.uuid4().hex
     history_len = len(history)
     agent_loop(history)
-    if len(history) > history_len:
-        save_session_history(current_session_id, history, token_tracker.get())
+    usage = token_tracker.get()
+    if len(history) > history_len and usage is not None:
+        save_session_history(current_session_id, history, usage)
 
 
 def _run_interactive(prompt: str | None = None, session_id: str | None = None) -> None:
@@ -61,8 +62,7 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
             sent_image_count[0] = count_images_in_history(history)
             next_indicator[0] = max_indicator_in_history(history) + 1
             print_session_history(chosen.history)
-            if chosen.last_usage is not None:
-                token_tracker.restore(chosen.last_usage)
+            token_tracker.restore(chosen.last_usage)
         except StopIteration:
             print("Session ID not found.\n")
 
@@ -109,8 +109,9 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
 
         if len(history) <= history_len:
             continue
-
-        save_session_history(current_session_id, history, token_tracker.get())
+        usage = token_tracker.get()
+        if usage is not None:
+            save_session_history(current_session_id, history, usage)
 
     if session_saved(current_session_id):
         print(f"\nResume the session with:\nmini --resume {current_session_id}\n")

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -11,7 +11,7 @@ from ..config import SESSION_DIR
 from .clipboard import extract_text_content
 from .display import clear_terminal, print_session_history
 from .display.picker import select_from_list
-from .token import token_tracker
+from .token import Usage, token_tracker
 
 
 @dataclass
@@ -20,7 +20,7 @@ class StoredSession:
     title: str
     updated_at: str
     history: list[MessageParam]
-    last_usage: tuple[int, int] | None = None
+    last_usage: Usage
 
 
 def session_path(session_id: str) -> Path:
@@ -52,7 +52,7 @@ def serialize_content(content: str | Iterable[object]) -> str | list[object]:
 def save_session_history(
     session_id: str,
     history: list[MessageParam],
-    last_usage: tuple[int, int] | None = None,
+    last_usage: Usage,
 ) -> None:
     ensure_session_dir()
     path = session_path(session_id)
@@ -66,33 +66,36 @@ def save_session_history(
                 }
             )
         )
-    if last_usage is not None:
-        lines.append(
-            json.dumps(
-                {
-                    "_meta": True,
-                    "input_tokens": last_usage[0],
-                    "output_tokens": last_usage[1],
-                }
-            )
+    lines.append(
+        json.dumps(
+            {
+                "input_tokens": last_usage.input_tokens,
+                "cache_creation_input_tokens": last_usage.cache_creation_input_tokens,
+                "cache_read_input_tokens": last_usage.cache_read_input_tokens,
+                "output_tokens": last_usage.output_tokens,
+            }
         )
-    path.write_text("\n".join(lines) + ("\n" if lines else ""))
+    )
+    path.write_text("\n".join(lines) + "\n")
 
 
 def load_session_history(
     session_id: str,
-) -> tuple[list[MessageParam], tuple[int, int] | None]:
+) -> tuple[list[MessageParam], Usage]:
     path = session_path(session_id)
-    history: list[MessageParam] = []
-    last_usage: tuple[int, int] | None = None
-    for line in path.read_text().splitlines():
-        if not line.strip():
-            continue
-        record = json.loads(line)
-        if record.get("_meta"):
-            last_usage = (record["input_tokens"], record["output_tokens"])
-        else:
-            history.append({"role": record["role"], "content": record["content"]})
+    lines = [line for line in path.read_text().splitlines() if line.strip()]
+    *message_lines, usage_line = lines
+    record = json.loads(usage_line)
+    last_usage = Usage(
+        input_tokens=record["input_tokens"],
+        cache_creation_input_tokens=record["cache_creation_input_tokens"],
+        cache_read_input_tokens=record["cache_read_input_tokens"],
+        output_tokens=record["output_tokens"],
+    )
+    history: list[MessageParam] = [
+        {"role": r["role"], "content": r["content"]}
+        for r in (json.loads(line) for line in message_lines)
+    ]
     return history, last_usage
 
 
@@ -187,6 +190,5 @@ def prompt_resume(
 
     chosen = next(stored for stored in sessions if stored.session_id == result)
     print_session_history(chosen.history)
-    if chosen.last_usage is not None:
-        token_tracker.restore(chosen.last_usage)
+    token_tracker.restore(chosen.last_usage)
     return chosen.session_id, chosen.history.copy(), True

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -87,10 +87,10 @@ def load_session_history(
     *message_lines, usage_line = lines
     record = json.loads(usage_line)
     last_usage = Usage(
-        input_tokens=record["input_tokens"],
-        cache_creation_input_tokens=record["cache_creation_input_tokens"],
-        cache_read_input_tokens=record["cache_read_input_tokens"],
-        output_tokens=record["output_tokens"],
+        input_tokens=record.get("input_tokens", 0),
+        cache_creation_input_tokens=record.get("cache_creation_input_tokens", 0),
+        cache_read_input_tokens=record.get("cache_read_input_tokens", 0),
+        output_tokens=record.get("output_tokens", 0),
     )
     history: list[MessageParam] = [
         {"role": r["role"], "content": r["content"]}

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -119,9 +119,7 @@ def list_sessions() -> list[StoredSession]:
     for path in SESSION_DIR.glob("*.jsonl"):
         try:
             history, last_usage = load_session_history(path.stem)
-        except OSError:
-            continue
-        except json.JSONDecodeError:
+        except OSError, json.JSONDecodeError, ValueError, KeyError:
             continue
         updated_at = datetime.fromtimestamp(path.stat().st_mtime, UTC).isoformat()
         sessions.append(

--- a/src/mini_agent/cli/status.py
+++ b/src/mini_agent/cli/status.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from ..config import config
+from .token import Usage, token_tracker
+
+
+def _usage_lines(usage: Usage | None) -> list[str]:
+    if usage is None:
+        return ["Usage: No usage data available"]
+
+    return [
+        f"Input: {usage.input_tokens}",
+        f"Output: {usage.output_tokens}",
+        f"Cache creation: {usage.cache_creation_input_tokens}",
+        f"Cache read: {usage.cache_read_input_tokens}",
+    ]
+
+
+def format_status_report(session_id: str) -> str:
+    lines = [
+        f"Model: {config.get_model()} {config.get_reasoning_effort()}",
+        f"Directory: {Path.cwd()}",
+        f"Session: {session_id}",
+        "",
+    ]
+    lines.extend(_usage_lines(token_tracker.get()))
+    return "\n".join(lines)

--- a/src/mini_agent/cli/token.py
+++ b/src/mini_agent/cli/token.py
@@ -1,19 +1,42 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Usage:
+    input_tokens: int
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
+    output_tokens: int
+
+    @property
+    def total_input_tokens(self) -> int:
+        return (
+            self.input_tokens
+            + self.cache_creation_input_tokens
+            + self.cache_read_input_tokens
+        )
+
+
 class TokenTracker:
     def __init__(self) -> None:
-        self._total_usage: tuple[int, int] | None = None
-        self._last_round: tuple[int, int] | None = None
+        self._total_usage: Usage | None = None
+        self._last_round: Usage | None = None
 
-    def update(self, input_tokens: int, output_tokens: int) -> None:
-        self._last_round = (input_tokens, output_tokens)
+    def update(self, usage: Usage) -> None:
+        self._last_round = usage
         if self._total_usage is None:
-            self._total_usage = (input_tokens, output_tokens)
+            self._total_usage = usage
         else:
-            self._total_usage = (
-                self._total_usage[0] + input_tokens,
-                self._total_usage[1] + output_tokens,
+            self._total_usage = Usage(
+                input_tokens=self._total_usage.input_tokens + usage.input_tokens,
+                cache_creation_input_tokens=self._total_usage.cache_creation_input_tokens
+                + usage.cache_creation_input_tokens,
+                cache_read_input_tokens=self._total_usage.cache_read_input_tokens
+                + usage.cache_read_input_tokens,
+                output_tokens=self._total_usage.output_tokens + usage.output_tokens,
             )
 
-    def restore(self, total_usage: tuple[int, int]) -> None:
+    def restore(self, total_usage: Usage) -> None:
         self._total_usage = total_usage
         self._last_round = None
 
@@ -21,10 +44,10 @@ class TokenTracker:
         self._total_usage = None
         self._last_round = None
 
-    def get(self) -> tuple[int, int] | None:
+    def get(self) -> Usage | None:
         return self._total_usage
 
-    def get_last_round(self) -> tuple[int, int] | None:
+    def get_last_round(self) -> Usage | None:
         return self._last_round
 
 

--- a/src/mini_agent/cli/token.py
+++ b/src/mini_agent/cli/token.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class Usage:
     input_tokens: int
     cache_creation_input_tokens: int


### PR DESCRIPTION
**BREAKING CHANGE**: Session file format has changed. Existing saved sessions are incompatible and cannot be resumed after this update.

- Introduce `Usage` dataclass (`input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`, `output_tokens`) to replace the opaque `tuple[int, int]` throughout the codebase
- Track cache creation and cache read tokens separately instead of collapsing them into a single input total
- Update toolbar display to show granular token breakdown (`in:`, `cre:`, `read:`, `↓`)
- Update session serialization/deserialization to store all four token fields; drop the old `_meta` sentinel line
- Raise default `max_tokens` fallback from 1024 to 32768
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kowyo/mini-agent/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
