### PR TITLE
feat(cli): live streaming output with Markdown rendering

### DIFF
--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import date
 
 import anthropic
@@ -7,10 +6,8 @@ from anthropic.types import (
     ToolUseBlock,
 )
 from rich.console import Console
-from rich.live import Live
-from rich.markdown import Markdown
 
-from ..cli.display import LIGHT_HINT_STYLE_RICH, print_tool_result, print_tool_start
+from ..cli.display import display_stream_events, print_tool_result, print_tool_start
 from ..cli.models import get_max_output_tokens
 from ..cli.token import Usage, token_tracker
 from ..config import WORKDIR, client, config
@@ -33,48 +30,6 @@ if skill_loader.skills:
 SYSTEM += (
     f"\nCurrent date: {date.today().isoformat()}\nCurrent working directory: {WORKDIR}"
 )
-
-
-def _display_stream_events(stream: anthropic.lib.streaming.MessageStream) -> None:
-    """Drive live Markdown display from stream events.
-
-    The SDK accumulates events into the final ``Message`` in parallel,
-    so this function only handles visual output.
-    """
-
-    live: Live | None = None
-    text = ""
-
-    for event in stream:
-        if event.type == "content_block_start":
-            text = ""
-
-        elif event.type == "content_block_delta":
-            delta = event.delta
-            if delta.type == "text_delta":
-                chunk, style = delta.text, None
-            elif delta.type == "thinking_delta":
-                chunk, style = delta.thinking, LIGHT_HINT_STYLE_RICH
-            else:
-                continue
-            text += chunk
-            if live is None:
-                live = Live(
-                    Markdown(""),
-                    console=console,
-                    refresh_per_second=15,
-                )
-                live.start()
-            live.update(Markdown(text, style=style or ""))
-
-        elif event.type == "content_block_stop" and live is not None:
-            live.stop()
-            live = None
-            console.print()
-            sys.stdout.flush()
-
-    if live is not None:
-        live.stop()
 
 
 def agent_loop(messages: list[MessageParam]) -> None:
@@ -118,7 +73,7 @@ def agent_loop(messages: list[MessageParam]) -> None:
 
                 with client.messages.stream(**stream_kwargs) as stream:
                     thinking_status.stop()
-                    _display_stream_events(stream)
+                    display_stream_events(stream)
                     response = stream.get_final_message()
 
             except (TypeError, anthropic.APIStatusError) as e:

--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -95,8 +95,10 @@ def _display_stream_events(stream: anthropic.lib.streaming.MessageStream) -> Non
             if current_block_type == "text":
                 _stop_live()
                 console.print()  # blank line after text block
+                sys.stdout.flush()
             elif current_block_type == "thinking":
                 console.print()  # newline after streaming thinking
+                sys.stdout.flush()
 
             current_block_type = None
 

--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -1,13 +1,13 @@
+import sys
 from datetime import date
 
 import anthropic
 from anthropic.types import (
     MessageParam,
-    TextBlock,
-    ThinkingBlock,
     ToolUseBlock,
 )
 from rich.console import Console
+from rich.live import Live
 from rich.markdown import Markdown
 
 from ..cli.display import LIGHT_HINT_STYLE_RICH, print_tool_result, print_tool_start
@@ -33,6 +33,74 @@ if skill_loader.skills:
 SYSTEM += (
     f"\nCurrent date: {date.today().isoformat()}\nCurrent working directory: {WORKDIR}"
 )
+
+
+def _display_stream_events(stream: anthropic.lib.streaming.MessageStream) -> None:
+    """Iterate stream events solely to drive live display.
+
+    The SDK's ``MessageStream`` accumulates events into the final
+    ``Message`` internally (via ``accumulate_event``) as each event is
+    yielded, so we only handle visual output here.  The properly
+    constructed response is obtained later with ``get_final_message()``.
+    """
+
+    live_display: Live | None = None
+    current_block_type: str | None = None
+    current_text = ""
+
+    def _stop_live() -> None:
+        nonlocal live_display
+        if live_display is not None:
+            live_display.stop()
+            live_display = None
+
+    for event in stream:
+        if event.type == "content_block_start":
+            cb = event.content_block
+            current_block_type = cb.type
+
+            if cb.type != "text":
+                _stop_live()
+            else:
+                current_text = ""
+
+        elif event.type == "content_block_delta":
+            delta = event.delta
+
+            if delta.type == "text_delta":
+                current_text += delta.text
+                if live_display is None:
+                    _stop_live()
+                    live_display = Live(
+                        Markdown(""),
+                        console=console,
+                        refresh_per_second=15,
+                        vertical_overflow="visible",
+                    )
+                    live_display.start()
+                if live_display is not None:
+                    live_display.update(Markdown(current_text))
+
+            elif delta.type == "thinking_delta":
+                # Print raw text — wrapping each delta in Markdown() causes
+                # Rich to emit unwanted newlines per chunk.
+                console.print(
+                    delta.thinking,
+                    end="",
+                    style=LIGHT_HINT_STYLE_RICH,
+                )
+                sys.stdout.flush()
+
+        elif event.type == "content_block_stop":
+            if current_block_type == "text":
+                _stop_live()
+                print()  # blank line after text block
+            elif current_block_type == "thinking":
+                print()  # newline after streaming thinking
+
+            current_block_type = None
+
+    _stop_live()
 
 
 def agent_loop(messages: list[MessageParam]) -> None:
@@ -73,21 +141,17 @@ def agent_loop(messages: list[MessageParam]) -> None:
                     stream_kwargs["thinking"] = thinking_param
                     if output_config is not None:
                         stream_kwargs["output_config"] = output_config
+
                 with client.messages.stream(**stream_kwargs) as stream:
-                    response = stream.get_final_message()
                     thinking_status.stop()
 
-                    for block in response.content:
-                        if isinstance(block, ThinkingBlock):
-                            console.print(
-                                Markdown(block.thinking),
-                                end="",
-                                style=LIGHT_HINT_STYLE_RICH,
-                            )
-                            print()
-                        elif isinstance(block, TextBlock):
-                            console.print(Markdown(block.text))
-                            print()
+                    # Drive live display from stream events.
+                    # The SDK accumulates into the final Message in parallel.
+                    _display_stream_events(stream)
+
+                    # Obtain the properly SDK-built response.
+                    response = stream.get_final_message()
+
             except (TypeError, anthropic.APIStatusError) as e:
                 thinking_status.stop()
                 print(f"Unexpected {e=}\n")
@@ -100,7 +164,7 @@ def agent_loop(messages: list[MessageParam]) -> None:
             cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
             token_tracker.update(
                 Usage(
-                    input_tokens=usage.input_tokens,
+                    input_tokens=usage.input_tokens or 0,
                     cache_creation_input_tokens=cache_create,
                     cache_read_input_tokens=cache_read,
                     output_tokens=usage.output_tokens,

--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -43,12 +43,10 @@ def _display_stream_events(stream: anthropic.lib.streaming.MessageStream) -> Non
     """
 
     live: Live | None = None
-    block_type: str | None = None
     text = ""
 
     for event in stream:
         if event.type == "content_block_start":
-            block_type = event.content_block.type
             text = ""
 
         elif event.type == "content_block_delta":
@@ -65,19 +63,15 @@ def _display_stream_events(stream: anthropic.lib.streaming.MessageStream) -> Non
                     Markdown(""),
                     console=console,
                     refresh_per_second=15,
-                    vertical_overflow="visible",
                 )
                 live.start()
             live.update(Markdown(text, style=style or ""))
 
-        elif event.type == "content_block_stop":
-            if live is not None:
-                live.stop()
-                live = None
-                console.print()
-                if block_type == "thinking":
-                    console.print()
-                sys.stdout.flush()
+        elif event.type == "content_block_stop" and live is not None:
+            live.stop()
+            live = None
+            console.print()
+            sys.stdout.flush()
 
     if live is not None:
         live.stop()

--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -36,73 +36,50 @@ SYSTEM += (
 
 
 def _display_stream_events(stream: anthropic.lib.streaming.MessageStream) -> None:
-    """Iterate stream events solely to drive live display.
+    """Drive live Markdown display from stream events.
 
-    The SDK's ``MessageStream`` accumulates events into the final
-    ``Message`` internally (via ``accumulate_event``) as each event is
-    yielded, so we only handle visual output here.  The properly
-    constructed response is obtained later with ``get_final_message()``.
+    The SDK accumulates events into the final ``Message`` in parallel,
+    so this function only handles visual output.
     """
 
-    live_display: Live | None = None
-    current_block_type: str | None = None
-    current_text = ""
-
-    def _stop_live() -> None:
-        nonlocal live_display
-        if live_display is not None:
-            live_display.stop()
-            live_display = None
+    live: Live | None = None
+    block_type: str | None = None
+    text = ""
 
     for event in stream:
         if event.type == "content_block_start":
-            cb = event.content_block
-            current_block_type = cb.type
-
-            if cb.type != "text":
-                _stop_live()
-            else:
-                current_text = ""
+            block_type = event.content_block.type
+            text = ""
 
         elif event.type == "content_block_delta":
             delta = event.delta
-
             if delta.type == "text_delta":
-                current_text += delta.text
-                if live_display is None:
-                    _stop_live()
-                    live_display = Live(
+                text += delta.text
+                if live is None:
+                    live = Live(
                         Markdown(""),
                         console=console,
                         refresh_per_second=15,
                         vertical_overflow="visible",
                     )
-                    live_display.start()
-                if live_display is not None:
-                    live_display.update(Markdown(current_text))
-
+                    live.start()
+                live.update(Markdown(text))
             elif delta.type == "thinking_delta":
-                # Print raw text — wrapping each delta in Markdown() causes
-                # Rich to emit unwanted newlines per chunk.
-                console.print(
-                    delta.thinking,
-                    end="",
-                    style=LIGHT_HINT_STYLE_RICH,
-                )
+                console.print(delta.thinking, end="", style=LIGHT_HINT_STYLE_RICH)
                 sys.stdout.flush()
 
         elif event.type == "content_block_stop":
-            if current_block_type == "text":
-                _stop_live()
-                console.print()  # blank line after text block
-                sys.stdout.flush()
-            elif current_block_type == "thinking":
-                console.print()  # newline after streaming thinking
-                sys.stdout.flush()
+            if block_type == "text" and live is not None:
+                live.stop()
+                live = None
+                console.print()
+            elif block_type == "thinking":
+                console.print()
+                console.print()
+            sys.stdout.flush()
 
-            current_block_type = None
-
-    _stop_live()
+    if live is not None:
+        live.stop()
 
 
 def agent_loop(messages: list[MessageParam]) -> None:

--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -54,29 +54,30 @@ def _display_stream_events(stream: anthropic.lib.streaming.MessageStream) -> Non
         elif event.type == "content_block_delta":
             delta = event.delta
             if delta.type == "text_delta":
-                text += delta.text
-                if live is None:
-                    live = Live(
-                        Markdown(""),
-                        console=console,
-                        refresh_per_second=15,
-                        vertical_overflow="visible",
-                    )
-                    live.start()
-                live.update(Markdown(text))
+                chunk, style = delta.text, None
             elif delta.type == "thinking_delta":
-                console.print(delta.thinking, end="", style=LIGHT_HINT_STYLE_RICH)
-                sys.stdout.flush()
+                chunk, style = delta.thinking, LIGHT_HINT_STYLE_RICH
+            else:
+                continue
+            text += chunk
+            if live is None:
+                live = Live(
+                    Markdown(""),
+                    console=console,
+                    refresh_per_second=15,
+                    vertical_overflow="visible",
+                )
+                live.start()
+            live.update(Markdown(text, style=style or ""))
 
         elif event.type == "content_block_stop":
-            if block_type == "text" and live is not None:
+            if live is not None:
                 live.stop()
                 live = None
                 console.print()
-            elif block_type == "thinking":
-                console.print()
-                console.print()
-            sys.stdout.flush()
+                if block_type == "thinking":
+                    console.print()
+                sys.stdout.flush()
 
     if live is not None:
         live.stop()
@@ -123,12 +124,7 @@ def agent_loop(messages: list[MessageParam]) -> None:
 
                 with client.messages.stream(**stream_kwargs) as stream:
                     thinking_status.stop()
-
-                    # Drive live display from stream events.
-                    # The SDK accumulates into the final Message in parallel.
                     _display_stream_events(stream)
-
-                    # Obtain the properly SDK-built response.
                     response = stream.get_final_message()
 
             except (TypeError, anthropic.APIStatusError) as e:

--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -88,7 +88,7 @@ def agent_loop(messages: list[MessageParam]) -> None:
             cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
             token_tracker.update(
                 Usage(
-                    input_tokens=usage.input_tokens or 0,
+                    input_tokens=usage.input_tokens,
                     cache_creation_input_tokens=cache_create,
                     cache_read_input_tokens=cache_read,
                     output_tokens=usage.output_tokens,

--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -129,6 +129,7 @@ def agent_loop(messages: list[MessageParam]) -> None:
             messages.append({"role": "user", "content": results})
 
     except KeyboardInterrupt:
+        print("\r", end="", flush=True)
         console.print(
             "[bold yellow]■ Conversation interrupted - tell the model what to do differently[/bold yellow]"
         )

--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -94,9 +94,9 @@ def _display_stream_events(stream: anthropic.lib.streaming.MessageStream) -> Non
         elif event.type == "content_block_stop":
             if current_block_type == "text":
                 _stop_live()
-                print()  # blank line after text block
+                console.print()  # blank line after text block
             elif current_block_type == "thinking":
-                print()  # newline after streaming thinking
+                console.print()  # newline after streaming thinking
 
             current_block_type = None
 

--- a/src/mini_agent/cli/display/__init__.py
+++ b/src/mini_agent/cli/display/__init__.py
@@ -9,6 +9,7 @@ from .printing import (
     print_tool_start,
     print_welcome_banner,
 )
+from .stream import display_stream_events
 from .theme import (
     ACCENT_COLOR,
     GREEN_BG,
@@ -30,6 +31,7 @@ __all__ = [
     "RED_BG",
     "RESET",
     "color_full_line",
+    "display_stream_events",
     "format_edit_diff",
     "get_status_toolbar",
     "print_box",

--- a/src/mini_agent/cli/display/stream.py
+++ b/src/mini_agent/cli/display/stream.py
@@ -23,33 +23,34 @@ def display_stream_events(stream: anthropic.lib.streaming.MessageStream) -> None
     live: Live | None = None
     text = ""
 
-    for event in stream:
-        if event.type == "content_block_start":
-            text = ""
+    try:
+        for event in stream:
+            if event.type == "content_block_start":
+                text = ""
 
-        elif event.type == "content_block_delta":
-            delta = cast(ContentBlockDeltaEvent, event).delta
-            if isinstance(delta, TextDelta):
-                chunk, style = delta.text, None
-            elif isinstance(delta, ThinkingDelta):
-                chunk, style = delta.thinking, LIGHT_HINT_STYLE_RICH
-            else:
-                continue
-            text += chunk
-            if live is None:
-                live = Live(
-                    Markdown(""),
-                    console=console,
-                    refresh_per_second=15,
-                )
-                live.start()
-            live.update(Markdown(text, style=style or ""))
+            elif event.type == "content_block_delta":
+                delta = cast(ContentBlockDeltaEvent, event).delta
+                if isinstance(delta, TextDelta):
+                    chunk, style = delta.text, None
+                elif isinstance(delta, ThinkingDelta):
+                    chunk, style = delta.thinking, LIGHT_HINT_STYLE_RICH
+                else:
+                    continue
+                text += chunk
+                if live is None:
+                    live = Live(
+                        Markdown(""),
+                        console=console,
+                        refresh_per_second=15,
+                    )
+                    live.start()
+                live.update(Markdown(text, style=style or ""))
 
-        elif event.type == "content_block_stop" and live is not None:
+            elif event.type == "content_block_stop" and live is not None:
+                live.stop()
+                live = None
+                console.print()
+                sys.stdout.flush()
+    finally:
+        if live is not None:
             live.stop()
-            live = None
-            console.print()
-            sys.stdout.flush()
-
-    if live is not None:
-        live.stop()

--- a/src/mini_agent/cli/display/stream.py
+++ b/src/mini_agent/cli/display/stream.py
@@ -1,7 +1,6 @@
 import sys
 from typing import cast
 
-import anthropic
 import anthropic.lib.streaming
 from anthropic.types import ContentBlockDeltaEvent, TextDelta, ThinkingDelta
 from rich.console import Console

--- a/src/mini_agent/cli/display/stream.py
+++ b/src/mini_agent/cli/display/stream.py
@@ -1,0 +1,55 @@
+import sys
+from typing import cast
+
+import anthropic
+import anthropic.lib.streaming
+from anthropic.types import ContentBlockDeltaEvent, TextDelta, ThinkingDelta
+from rich.console import Console
+from rich.live import Live
+from rich.markdown import Markdown
+
+from .theme import LIGHT_HINT_STYLE_RICH
+
+console = Console()
+
+
+def display_stream_events(stream: anthropic.lib.streaming.MessageStream) -> None:
+    """Drive live Markdown display from stream events.
+
+    The SDK accumulates events into the final ``Message`` in parallel,
+    so this function only handles visual output.
+    """
+
+    live: Live | None = None
+    text = ""
+
+    for event in stream:
+        if event.type == "content_block_start":
+            text = ""
+
+        elif event.type == "content_block_delta":
+            delta = cast(ContentBlockDeltaEvent, event).delta
+            if isinstance(delta, TextDelta):
+                chunk, style = delta.text, None
+            elif isinstance(delta, ThinkingDelta):
+                chunk, style = delta.thinking, LIGHT_HINT_STYLE_RICH
+            else:
+                continue
+            text += chunk
+            if live is None:
+                live = Live(
+                    Markdown(""),
+                    console=console,
+                    refresh_per_second=15,
+                )
+                live.start()
+            live.update(Markdown(text, style=style or ""))
+
+        elif event.type == "content_block_stop" and live is not None:
+            live.stop()
+            live = None
+            console.print()
+            sys.stdout.flush()
+
+    if live is not None:
+        live.stop()


### PR DESCRIPTION
## Description

Adds live streaming output so users see AI responses token-by-token as they arrive, rather than waiting for the full response. Markdown rendering is preserved during streaming via `rich.live.Live`.

### How it works

The `display_stream_events()` function (extracted into `cli/display/stream.py`) iterates over stream events from the Anthropic SDK and drives a `rich.live.Live` display:

- **Text deltas** → re-rendered incrementally — code fences, headings, bold, lists all appear live as the model writes them
- **Thinking deltas** → streamed inline with `LIGHT_HINT_STYLE_RICH` and flushed immediately for zero-delay feel
- **Content blocks** → separated by a blank line for readability

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Test

- [x] `ruff check` and `ruff format` pass

### Additional notes

When the thinking text is longer than the terminal window,  the last line of the terminal is replaced with “…”.

This is a known limitation with `rich.Live` (see https://rich.readthedocs.io/en/latest/live.html#vertical-overflow and https://github.com/Textualize/rich/issues/3263), I have tested `vertical_overflow = "visible"` as well, which will eventually make the terminal unreadable after scrolling.

Would rework sooner with Textual as suggested in https://github.com/Textualize/rich/issues/3263#issuecomment-1905680589