### PR TITLE
feat: add AGENTS.md support for project-level context injection

### DIFF
--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 import anthropic
 from anthropic.types import (
     MessageParam,
@@ -11,26 +9,11 @@ from rich.status import Status
 from ..cli.display import display_stream_events, print_tool_result, print_tool_start
 from ..cli.models import get_max_output_tokens
 from ..cli.token import Usage, token_tracker
-from ..config import WORKDIR, client, config
-from .skills import skill_loader
+from ..config import client, config
+from ..system_prompt import SYSTEM
 from .tools import TOOL_HANDLERS, TOOLS
 
 console = Console()
-
-TOOLS_LIST = "\n".join(f"- {tool['name']}: {tool['description']}" for tool in TOOLS)
-
-_SYSTEM_BASE = f"""You are an expert coding assistant. You help users by reading files, executing commands, editing code, and writing new files.
-
-Available tools:
-{TOOLS_LIST}
-"""
-
-SYSTEM = _SYSTEM_BASE
-if skill_loader.skills:
-    SYSTEM += f"\nAvailable skills:\n{skill_loader.get_descriptions()}\n"
-SYSTEM += (
-    f"\nCurrent date: {date.today().isoformat()}\nCurrent working directory: {WORKDIR}"
-)
 
 
 def agent_loop(messages: list[MessageParam]) -> None:

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -11,6 +11,7 @@ from ..config import (
     REASONING_EFFORT_LEVELS,
     config,
 )
+from ..system_prompt import context_files as loaded_context_files
 from .display import (
     ACCENT_COLOR,
     clear_prompt_line,
@@ -41,8 +42,19 @@ from .token import token_tracker
 console = Console()
 
 
+def _print_context_files() -> None:
+    """Print loaded context files on startup."""
+    if not loaded_context_files:
+        return
+    console.print("[dim]Loaded context files:[/dim]")
+    for path in loaded_context_files:
+        console.print(f"  [dim]• {path}[/dim]")
+    print()
+
+
 def _run_non_interactive(prompt: str) -> None:
     """Run the agent on a single prompt and exit (non-interactive mode)."""
+    _print_context_files()
     history: list[MessageParam] = [{"role": "user", "content": prompt}]
     current_session_id = uuid.uuid4().hex
     history_len = len(history)
@@ -55,6 +67,7 @@ def _run_non_interactive(prompt: str) -> None:
 def _run_interactive(prompt: str | None = None, session_id: str | None = None) -> None:
     """Run the interactive TUI session."""
     print_welcome_banner()
+    _print_context_files()
     history: list[MessageParam] = []
     current_session_id = uuid.uuid4().hex
     session, pre_run, attached_images, sent_image_count, next_indicator = build_session(

--- a/src/mini_agent/system_prompt.py
+++ b/src/mini_agent/system_prompt.py
@@ -5,14 +5,13 @@ from pathlib import Path
 
 from .agent.skills import skill_loader
 from .agent.tools import TOOLS
-from .config import WORKDIR
+from .config import CONFIG_DIR, WORKDIR
 
 # ---------------------------------------------------------------------------
 # Context file discovery
 # ---------------------------------------------------------------------------
 
 CONTEXT_FILENAMES = ("AGENTS.md",)
-CONFIG_DIR = Path.home() / ".mini-agent"
 
 
 def _find_context_in_dir(directory: Path) -> Path | None:

--- a/src/mini_agent/system_prompt.py
+++ b/src/mini_agent/system_prompt.py
@@ -78,11 +78,11 @@ def _build_context_section(files: list[Path]) -> str:
     ]
     for path in files:
         try:
-            content = path.read_text()
+            content = path.read_text().strip()
         except PermissionError, OSError:
             continue
-        sections.append(f"## {path}\n\n{content}\n")
-    return "\n".join(sections)
+        sections.append(f"\n## {path}\n\n{content}\n")
+    return "".join(sections)
 
 
 # ---------------------------------------------------------------------------

--- a/src/mini_agent/system_prompt.py
+++ b/src/mini_agent/system_prompt.py
@@ -1,0 +1,111 @@
+"""Build the system prompt, including project-level AGENTS.md discovery."""
+
+from datetime import date
+from pathlib import Path
+
+from .agent.skills import skill_loader
+from .agent.tools import TOOLS
+from .config import WORKDIR
+
+# ---------------------------------------------------------------------------
+# Context file discovery
+# ---------------------------------------------------------------------------
+
+CONTEXT_FILENAMES = ("AGENTS.md",)
+CONFIG_DIR = Path.home() / ".mini-agent"
+
+
+def _find_context_in_dir(directory: Path) -> Path | None:
+    """Check if any context file exists in *directory* (case-insensitive)."""
+    try:
+        entries = {e.name.lower(): e for e in directory.iterdir()}
+    except PermissionError, OSError:
+        return None
+    for name in CONTEXT_FILENAMES:
+        entry = entries.get(name.lower())
+        if entry is not None and entry.is_file():
+            return entry
+    return None
+
+
+def discover_context_files(cwd: Path | None = None) -> list[Path]:
+    """Return an ordered list of context file paths to load.
+
+    Order: global first, then ancestors from root → cwd (most specific last).
+    Duplicate paths are removed.
+    """
+    if cwd is None:
+        cwd = Path.cwd()
+
+    seen: set[Path] = set()
+    result: list[Path] = []
+
+    def _add(path: Path | None) -> None:
+        if path is None:
+            return
+        resolved = path.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            result.append(resolved)
+
+    # 1. Global config
+    _add(_find_context_in_dir(CONFIG_DIR))
+
+    # 2. Walk from cwd up to root, collect ancestors
+    ancestors: list[Path] = []
+    current = cwd.resolve()
+    while True:
+        ancestors.append(current)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+
+    # ancestors is [cwd, parent, ..., root]; reverse so root comes first
+    for directory in reversed(ancestors):
+        _add(_find_context_in_dir(directory))
+
+    return result
+
+
+def _build_context_section(files: list[Path]) -> str:
+    """Build the ``# Project Context`` section for the system prompt."""
+    if not files:
+        return ""
+
+    sections = [
+        "\n# Project Context\n\nProject-specific instructions and guidelines:\n"
+    ]
+    for path in files:
+        try:
+            content = path.read_text()
+        except PermissionError, OSError:
+            continue
+        sections.append(f"## {path}\n\n{content}\n")
+    return "\n".join(sections)
+
+
+# ---------------------------------------------------------------------------
+# System prompt assembly
+# ---------------------------------------------------------------------------
+
+TOOLS_LIST = "\n".join(f"- {tool['name']}: {tool['description']}" for tool in TOOLS)
+
+_SYSTEM_BASE = f"""You are an expert coding assistant. You help users by reading files, executing commands, editing code, and writing new files.
+
+Available tools:
+{TOOLS_LIST}
+"""
+
+SYSTEM = _SYSTEM_BASE
+if skill_loader.skills:
+    SYSTEM += f"\nAvailable skills:\n{skill_loader.get_descriptions()}\n"
+
+context_files = discover_context_files()
+_context_section = _build_context_section(context_files)
+if _context_section:
+    SYSTEM += _context_section
+
+SYSTEM += (
+    f"\nCurrent date: {date.today().isoformat()}\nCurrent working directory: {WORKDIR}"
+)


### PR DESCRIPTION
## Description

Adds support for loading `AGENTS.md` files into the system prompt at startup, enabling layered project-level instructions.

Closes #40

**How it works:**
1. Scans `~/.mini-agent/` for a global `AGENTS.md`
2. Walks from the filesystem root down to cwd, checking each ancestor directory
3. All discovered files are deduplicated and injected verbatim into the system prompt under a `# Project Context` section (root-first order, so the most specific rules appear last)
4. Loaded files are listed on startup so the user can verify what was picked up

Also extracts all system prompt construction logic from `agent/agent.py` into a new `system_prompt.py` module.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test

<img width="674" height="420" alt="image" src="https://github.com/user-attachments/assets/2a9fdb24-45dc-4e70-b3ee-e59a37a78cba" />
