### PR TITLE
feat(agent): add blocked file patterns and write-path safety to bash tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,20 @@ jobs:
         with:
           args: "format --check --diff"
 
-  build:
+  test:
     needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Run tests
+        run: uv run pytest -v tests/
+
+  build:
+    needs: [lint, test]
     strategy:
       matrix:
         include:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: prepare format lint check build clean
+.PHONY: prepare format lint check type-check test build clean
 
 prepare:
 	uv sync --group dev
@@ -13,7 +13,10 @@ lint:
 type-check:
 	uv run ty check src/
 
-check: format lint
+test:
+	uv run pytest -v tests/
+
+check: format lint test
 
 build:
 	uv build --wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "prek>=0.3.9",
+    "pytest>=9.0.3",
     "ruff>=0.15.11",
     "ty>=0.0.32",
 ]

--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -95,7 +95,7 @@ def run_bash(command: str) -> str:
 
 def run_read(path: str, limit: int | None = None) -> str:
     try:
-        file_path = Path(path).resolve()
+        file_path = safe_path(path)
         _check_blocked(file_path)
         text = file_path.read_text()
         lines = text.splitlines()

--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -19,9 +20,14 @@ def safe_path(path_str: str) -> Path:
 
 
 def run_bash(command: str) -> str:
-    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot", "> /dev/"]
-    if any(token in command for token in dangerous):
-        return "Error: Dangerous command blocked"
+    dangerous = ["rm -rf /", "sudo", "shutdown", "reboot"]
+    for token in dangerous:
+        if token in command:
+            return f"<system-reminder>\nError: dangerous command blocked (matched: {token!r})\n</system-reminder>"
+
+    match = re.search(r"(?:[&\d]*>+)\s*/dev/(\w+)", command)
+    if match and match.group(1) != "null":
+        return f"<system-reminder>\nError: dangerous command blocked (matched: /dev/{match.group(1)})\n</system-reminder>"
 
     try:
         result = subprocess.run(
@@ -35,7 +41,7 @@ def run_bash(command: str) -> str:
             timeout=120,
         )
     except subprocess.TimeoutExpired:
-        return "Error: Timeout (120s)"
+        return "<system-reminder>\nError: timeout (120s)\n</system-reminder>"
 
     output = (result.stdout + result.stderr).strip()
     return output[:50000] if output else "(no output)"

--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -8,15 +8,42 @@ from anthropic.types import ToolParam
 from ..config import WORKDIR
 from .skills import skill_loader
 
+BLOCKED_FILE_PATTERNS: list[str] = [
+    ".env",
+    "id_ed25519",
+    "authorized_keys",
+    "known_hosts",
+]
+
 
 def safe_path(path_str: str) -> Path:
     path = Path(path_str)
     path = path.resolve() if path.is_absolute() else (WORKDIR / path_str).resolve()
 
-    if path.is_relative_to(WORKDIR) or path.is_relative_to(Path("/tmp")):
+    if path.is_relative_to(WORKDIR.resolve()) or path.is_relative_to(
+        Path("/tmp").resolve()
+    ):
         return path
 
     raise ValueError(f"Path escapes workspace: {path_str}")
+
+
+def _check_blocked(path: Path) -> None:
+    for pattern in BLOCKED_FILE_PATTERNS:
+        if pattern in path.name:
+            raise ValueError(f"'{path.name}' is blocked for security reasons")
+
+
+def _check_write_target(path_str: str) -> str | None:
+    if path_str.startswith("/dev/"):
+        return None
+    if path_str.startswith(("/tmp", WORKDIR.as_posix())):
+        return None
+    try:
+        safe_path(path_str)
+        return None
+    except ValueError:
+        return f"<system-reminder>\nError: blocked — writes to path outside workspace: {path_str}\n</system-reminder>"
 
 
 def run_bash(command: str) -> str:
@@ -25,9 +52,28 @@ def run_bash(command: str) -> str:
         if token in command:
             return f"<system-reminder>\nError: dangerous command blocked (matched: {token!r})\n</system-reminder>"
 
+    for pattern in BLOCKED_FILE_PATTERNS:
+        if pattern in command:
+            return f"<system-reminder>\nError: command references blocked file pattern '{pattern}'\n</system-reminder>"
+
     match = re.search(r"(?:[&\d]*>+)\s*/dev/(\w+)", command)
     if match and match.group(1) != "null":
         return f"<system-reminder>\nError: dangerous command blocked (matched: /dev/{match.group(1)})\n</system-reminder>"
+
+    for match in re.finditer(r"(?:^|[\s|&;])[\w]*>+\s*(/[\w./-]+)", command):
+        err = _check_write_target(match.group(1))
+        if err:
+            return err
+
+    for match in re.finditer(r"\btee\s+(/[\w./-]+)", command):
+        err = _check_write_target(match.group(1))
+        if err:
+            return err
+
+    for match in re.finditer(r"\bdd\s+.*?of=(/[\w./-]+)", command):
+        err = _check_write_target(match.group(1))
+        if err:
+            return err
 
     try:
         result = subprocess.run(
@@ -49,7 +95,9 @@ def run_bash(command: str) -> str:
 
 def run_read(path: str, limit: int | None = None) -> str:
     try:
-        text = safe_path(path).read_text()
+        file_path = Path(path).resolve()
+        _check_blocked(file_path)
+        text = file_path.read_text()
         lines = text.splitlines()
         if limit and limit < len(lines):
             remaining = len(lines) - limit
@@ -62,6 +110,7 @@ def run_read(path: str, limit: int | None = None) -> str:
 def run_write(path: str, content: str) -> str:
     try:
         file_path = safe_path(path)
+        _check_blocked(file_path)
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text(content)
         return f"Wrote {len(content)} bytes to {path}"
@@ -72,6 +121,7 @@ def run_write(path: str, content: str) -> str:
 def run_edit(path: str, old_text: str, new_text: str) -> str:
     try:
         file_path = safe_path(path)
+        _check_blocked(file_path)
         content = file_path.read_text()
         if old_text not in content:
             return f"Error: Text not found in {path}"

--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -58,17 +58,17 @@ def run_bash(command: str) -> str:
     if match and match.group(1) != "null":
         return f"<system-reminder>\nError: dangerous command blocked (matched: /dev/{match.group(1)})\n</system-reminder>"
 
-    for match in re.finditer(r"(?:^|[\s|&;])[\w]*>+\s*(/[\w./-]+)", command):
+    for match in re.finditer(r"(?:^|[\s|&;])[\w]*>+\|?\s*([./\w-]+)", command):
         err = _check_write_target(match.group(1))
         if err:
             return err
 
-    for match in re.finditer(r"\btee\s+(/[\w./-]+)", command):
+    for match in re.finditer(r"\btee\s+([./\w-]+)", command):
         err = _check_write_target(match.group(1))
         if err:
             return err
 
-    for match in re.finditer(r"\bdd\s+.*?of=(/[\w./-]+)", command):
+    for match in re.finditer(r"\bdd\s+.*?of=([./\w-]+)", command):
         err = _check_write_target(match.group(1))
         if err:
             return err

--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -37,8 +37,6 @@ def _check_blocked(path: Path) -> None:
 def _check_write_target(path_str: str) -> str | None:
     if path_str.startswith("/dev/"):
         return None
-    if path_str.startswith(("/tmp", WORKDIR.as_posix())):
-        return None
     try:
         safe_path(path_str)
         return None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -171,14 +171,8 @@ class TestRunRead:
             path.unlink(missing_ok=True)
 
     def test_read_any_path_allowed(self) -> None:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write("outside content")
-            path = Path(f.name)
-        try:
-            result = run_read(str(path))
-            assert "Error" in result
-        finally:
-            path.unlink(missing_ok=True)
+        result = run_read("/etc/passwd")
+        assert "Error" in result
 
     def test_read_env_file_blocked(self) -> None:
         with tempfile.NamedTemporaryFile(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,278 @@
+"""Tests for agent tools module."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mini_agent.agent.tools import (
+    run_bash,
+    run_edit,
+    run_read,
+    run_write,
+    safe_path,
+)
+from mini_agent.config import WORKDIR
+
+
+class TestRunBash:
+    def test_dangerous_rm(self) -> None:
+        result = run_bash("rm -rf /")
+        assert "blocked" in result and "rm -rf /" in result
+
+    def test_dangerous_sudo(self) -> None:
+        result = run_bash("sudo ls")
+        assert "blocked" in result
+
+    def test_dangerous_shutdown(self) -> None:
+        result = run_bash("shutdown -h now")
+        assert "blocked" in result
+
+    def test_dangerous_reboot(self) -> None:
+        result = run_bash("reboot")
+        assert "blocked" in result
+
+    def test_dev_non_null_blocked(self) -> None:
+        result = run_bash("echo hi > /dev/sda")
+        assert "blocked" in result and "/dev/sda" in result
+
+    def test_dev_null_allowed(self) -> None:
+        result = run_bash("echo hi > /dev/null")
+        assert "blocked" not in result
+
+    def test_normal_command(self) -> None:
+        result = run_bash("echo hello world")
+        assert result == "hello world"
+
+    def test_empty_output(self) -> None:
+        result = run_bash("true")
+        assert result == "(no output)"
+
+    def test_output_truncation(self) -> None:
+        result = run_bash("python3 -c \"print('x'*50001)\"")
+        assert len(result) == 50000
+
+    def test_stderr_captured(self) -> None:
+        result = run_bash("python3 -c \"import sys; print('err', file=sys.stderr)\"")
+        assert result == "err"
+
+    def test_blocked_env_file_cat(self) -> None:
+        result = run_bash("cat /path/to/.env")
+        assert "blocked" in result and ".env" in result
+
+    def test_blocked_env_file_ls(self) -> None:
+        result = run_bash("ls -la .env.prod")
+        assert "blocked" in result
+
+    def test_blocked_ssh_key(self) -> None:
+        result = run_bash("cat ~/.ssh/id_ed25519")
+        assert "blocked" in result
+
+    def test_blocked_authorized_keys(self) -> None:
+        result = run_bash("cat ~/.ssh/authorized_keys")
+        assert "blocked" in result
+
+    def test_write_redirect_to_etc_blocked(self) -> None:
+        result = run_bash("echo hi > /etc/evil.conf")
+        assert "blocked" in result and "/etc/evil.conf" in result
+
+    def test_append_redirect_to_etc_blocked(self) -> None:
+        result = run_bash("echo hi >> /etc/passwd")
+        assert "blocked" in result
+
+    def test_write_redirect_to_tmp_allowed(self) -> None:
+        path = Path(f"/tmp/test_bash_{os.urandom(4).hex()}.txt")
+        try:
+            result = run_bash(f"echo hi > {path}")
+            assert "blocked" not in result
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_tee_to_etc_blocked(self) -> None:
+        result = run_bash("tee /etc/evil.conf")
+        assert "blocked" in result
+
+    def test_tee_to_tmp_allowed(self) -> None:
+        path = Path(f"/tmp/test_tee_{os.urandom(4).hex()}.txt")
+        try:
+            result = run_bash(f"tee {path}")
+            assert "blocked" not in result
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_dd_of_etc_blocked(self) -> None:
+        result = run_bash("dd if=/dev/zero of=/etc/evil count=1")
+        assert "blocked" in result
+
+    def test_dd_of_tmp_allowed(self) -> None:
+        path = Path(f"/tmp/test_dd_{os.urandom(4).hex()}")
+        try:
+            result = run_bash(f"dd if=/dev/zero of={path} count=1")
+            assert "blocked" not in result
+        finally:
+            path.unlink(missing_ok=True)
+
+
+class TestSafePath:
+    def test_relative_path_within_workdir(self) -> None:
+        p = safe_path(".")
+        assert p == WORKDIR.resolve()
+
+    def test_relative_path_subdir(self) -> None:
+        p = safe_path("src")
+        assert p == (WORKDIR / "src").resolve()
+
+    def test_relative_path_with_dotdot_inside(self) -> None:
+        sub = WORKDIR / "src" / ".."
+        p = safe_path(str(sub))
+        assert p == WORKDIR.resolve()
+
+    def test_tmp_absolute_path(self) -> None:
+        p = safe_path("/tmp")
+        assert p == Path("/tmp").resolve()
+
+    def test_absolute_path_escapes(self) -> None:
+        with pytest.raises(ValueError, match="Path escapes workspace"):
+            safe_path("/etc/passwd")
+
+    def test_relative_path_escapes(self) -> None:
+        with pytest.raises(ValueError, match="Path escapes workspace"):
+            safe_path("../../etc/passwd")
+
+
+class TestRunRead:
+    def test_read_safe_path_allowed(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False, dir="/tmp"
+        ) as f:
+            f.write("hello world")
+            path = Path(f.name)
+        try:
+            result = run_read(str(path))
+            assert result == "hello world"
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_read_any_path_allowed(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("outside content")
+            path = Path(f.name)
+        try:
+            result = run_read(str(path))
+            assert result == "outside content"
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_read_env_file_blocked(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".env", delete=False, dir="/tmp"
+        ) as f:
+            f.write("SECRET=xxx")
+            path = Path(f.name)
+        try:
+            result = run_read(str(path))
+            assert "blocked" in result and ".env" in result
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_read_ssh_key_blocked(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="id_ed25519", delete=False, dir="/tmp"
+        ) as f:
+            f.write("-----BEGIN OPENSSH PRIVATE KEY-----")
+            path = Path(f.name)
+        try:
+            result = run_read(str(path))
+            assert "blocked" in result and "id_ed25519" in result
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_read_nonexistent_file(self) -> None:
+        result = run_read("/nonexistent/path.txt")
+        assert "Error" in result
+
+    def test_read_with_limit(self) -> None:
+        content = "\n".join(f"line {i}" for i in range(20))
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False, dir="/tmp"
+        ) as f:
+            f.write(content)
+            path = Path(f.name)
+        try:
+            result = run_read(str(path), limit=5)
+            lines = result.splitlines()
+            assert len(lines) == 6
+            assert "... (15 more lines)" in result
+        finally:
+            path.unlink(missing_ok=True)
+
+
+class TestRunWrite:
+    def test_write_in_tmp(self) -> None:
+        path = Path("/tmp") / f"test_write_{os.urandom(4).hex()}.txt"
+        try:
+            result = run_write(str(path), "content")
+            assert "Wrote" in result
+            assert path.read_text() == "content"
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_write_env_file_blocked(self) -> None:
+        path = Path("/tmp") / f".env.{os.urandom(4).hex()}"
+        result = run_write(str(path), "SECRET=xxx")
+        assert "blocked" in result
+        assert not path.exists()
+
+    def test_write_ssh_key_blocked(self) -> None:
+        path = Path("/tmp") / f"id_ed25519_{os.urandom(4).hex()}"
+        result = run_write(str(path), "ssh-key")
+        assert "blocked" in result
+        assert not path.exists()
+
+    def test_write_outside_safe_path_blocked(self) -> None:
+        result = run_write("/etc/evil.sh", "rm -rf /")
+        assert "Error" in result
+
+
+class TestRunEdit:
+    def test_edit_safe_path(self) -> None:
+        path = Path("/tmp") / f"test_edit_{os.urandom(4).hex()}.txt"
+        try:
+            path.write_text("hello world")
+            result = run_edit(str(path), "world", "there")
+            assert result == f"Edited {path}"
+            assert path.read_text() == "hello there"
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_edit_env_file_blocked(self) -> None:
+        path = Path("/tmp") / f".env.{os.urandom(4).hex()}"
+        path.write_text("OLD=val")
+        try:
+            result = run_edit(str(path), "OLD", "NEW")
+            assert "blocked" in result
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_edit_ssh_key_blocked(self) -> None:
+        path = Path("/tmp") / f"id_ed25519_{os.urandom(4).hex()}"
+        path.write_text("old key data")
+        try:
+            result = run_edit(str(path), "old", "new")
+            assert "blocked" in result
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_edit_outside_safe_path_blocked(self) -> None:
+        result = run_edit("/etc/passwd", "root", "nope")
+        assert "Error" in result
+
+    def test_edit_text_not_found(self) -> None:
+        path = Path("/tmp") / f"test_edit_{os.urandom(4).hex()}.txt"
+        try:
+            path.write_text("hello")
+            result = run_edit(str(path), "nope", "new")
+            assert "not found" in result
+        finally:
+            path.unlink(missing_ok=True)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -89,6 +89,22 @@ class TestRunBash:
         finally:
             path.unlink(missing_ok=True)
 
+    def test_write_relative_dotdot_blocked(self) -> None:
+        result = run_bash("echo hi > ../etc/evil.conf")
+        assert "blocked" in result
+
+    def test_write_relative_path_blocked(self) -> None:
+        result = run_bash("echo hi > foo/../../etc/evil.conf")
+        assert "blocked" in result
+
+    def test_tee_relative_dotdot_blocked(self) -> None:
+        result = run_bash("tee ../outside.txt")
+        assert "blocked" in result
+
+    def test_dd_of_relative_dotdot_blocked(self) -> None:
+        result = run_bash("dd if=/dev/zero of=../outside count=1")
+        assert "blocked" in result
+
     def test_tee_to_etc_blocked(self) -> None:
         result = run_bash("tee /etc/evil.conf")
         assert "blocked" in result

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -160,7 +160,7 @@ class TestRunRead:
             path = Path(f.name)
         try:
             result = run_read(str(path))
-            assert result == "outside content"
+            assert "Error" in result
         finally:
             path.unlink(missing_ok=True)
 

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -117,6 +126,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -193,6 +211,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "prek" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -212,8 +231,18 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "prek", specifier = ">=0.3.9" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.15.11" },
     { name = "ty", specifier = ">=0.0.32" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
 ]
 
 [[package]]
@@ -247,6 +276,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
     { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
     { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -371,6 +409,22 @@ sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/bb/f777cc9e775fc7dae77b569254570fe46eb842516b3e4fe383ab49eab598/pyobjc_framework_cocoa-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:03342a60fc0015bcdf9b93ac0b4f457d3938e9ef761b28df9564c91a14f0129a", size = 384932, upload-time = "2025-11-14T09:42:29.771Z" },
     { url = "https://files.pythonhosted.org/packages/58/27/b457b7b37089cad692c8aada90119162dfb4c4a16f513b79a8b2b022b33b/pyobjc_framework_cocoa-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6ba1dc1bfa4da42d04e93d2363491275fb2e2be5c20790e561c8a9e09b8cf2cc", size = 388970, upload-time = "2025-11-14T09:42:53.964Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Add blocked file pattern enforcement and write-path safety to the agent tools.

### Changes

- **BLOCKED_FILE_PATTERNS**: Add `.env`, `id_ed25519`, `authorized_keys`, `known_hosts` as blocked patterns across all file tools
- **`run_read`**: Now checks blocked patterns (was reading any file unrestricted)
- **`run_write`** / **`run_edit`**: Now check blocked patterns (previously only checked `safe_path`)
- **`run_bash`**: Add blocked pattern matching, write-redirect target validation (`>`, `>>`), `tee` target validation, and `dd of=` target validation
- **Tests**: Full test coverage for all tools (42 tests):
  - `run_bash`: dangerous commands, `/dev/*` blocking, output truncation, blocked file patterns, write target validation
  - `safe_path`: relative paths, `..` traversal, absolute paths
  - `run_read`, `run_write`, `run_edit`: happy paths, blocked patterns, error cases

Fixes #52

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Test

```
42 passed in 0.33s
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kowyo/mini-agent/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
