### PR TITLE
feat(cli): add /copy command to copy last assistant response to clipboard

### DIFF
--- a/src/mini_agent/cli/clipboard.py
+++ b/src/mini_agent/cli/clipboard.py
@@ -5,7 +5,7 @@ import sys
 from collections.abc import Iterable
 from typing import cast
 
-from anthropic.types import ImageBlockParam
+from anthropic.types import ImageBlockParam, MessageParam
 from PIL import Image, ImageGrab
 
 
@@ -108,19 +108,33 @@ def extract_text_content(content: Iterable[object] | str) -> str:
     return "\n".join(texts) if texts else ""
 
 
-def copy_to_clipboard(text: str) -> None:
-    """Copy text to the system clipboard."""
-    if sys.platform == "darwin":
-        subprocess.run(["pbcopy"], input=text, text=True, check=False)
-    elif sys.platform == "win32":
-        subprocess.run(["clip"], input=text, text=True, check=False)
-    else:
-        for cmd in (["wl-copy"], ["xclip", "-selection", "clipboard"]):
-            try:
-                subprocess.run(cmd, input=text, text=True, check=True)
+def copy_to_clipboard(text: str) -> bool:
+    try:
+        if sys.platform == "darwin":
+            subprocess.run(["pbcopy"], input=text, text=True, check=True)
+        elif sys.platform == "win32":
+            subprocess.run(["clip"], input=text, text=True, check=True)
+        else:
+            for cmd in (["wl-copy"], ["xclip", "-selection", "clipboard"]):
+                try:
+                    subprocess.run(cmd, input=text, text=True, check=True)
+                    return True
+                except FileNotFoundError, subprocess.CalledProcessError:
+                    continue
+            return False
+        return True
+    except FileNotFoundError, subprocess.CalledProcessError:
+        return False
+
+
+def copy_last_assistant_text(history: Iterable[MessageParam]) -> None:
+    for message in reversed(list(history)):
+        if message["role"] == "assistant":
+            text = extract_text_content(message["content"])
+            if text:
+                if copy_to_clipboard(text):
+                    print("Copied to clipboard.")
+                else:
+                    print("Failed to copy — no clipboard tool available.")
                 return
-            except FileNotFoundError, subprocess.CalledProcessError:
-                continue
-        subprocess.run(
-            ["xclip", "-selection", "clipboard"], input=text, text=True, check=False
-        )
+    print("No assistant message to copy.")

--- a/src/mini_agent/cli/clipboard.py
+++ b/src/mini_agent/cli/clipboard.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import subprocess
 import sys
 from collections.abc import Iterable
 from typing import cast
@@ -83,19 +84,43 @@ def create_image_content(image: Image.Image) -> ImageBlockParam:
     }
 
 
+def _is_text_block(block: object) -> str | None:
+    """Extract text from a content block. Returns text or None if not a text block."""
+    if isinstance(block, dict):
+        d = cast("dict[str, object]", block)
+        block_type = d.get("type")
+        text = d.get("text", "")
+    else:
+        block_type = getattr(block, "type", None)
+        text = getattr(block, "text", None)
+
+    if block_type == "text" and isinstance(text, str) and text.strip():
+        return text.strip()
+    return None
+
+
 def extract_text_content(content: Iterable[object] | str) -> str:
     if isinstance(content, str):
         return content
 
-    blocks = [cast("dict[str, object]", b) for b in content if isinstance(b, dict)]
+    texts = [text for block in content if (text := _is_text_block(block)) is not None]
 
-    texts = [
-        cast(str, b.get("text", "")).strip()
-        for b in blocks
-        if b.get("type") == "text" and isinstance(b.get("text", ""), str)
-    ]
+    return "\n".join(texts) if texts else ""
 
-    if texts:
-        return "\n".join(text for text in texts if text)
 
-    return ""
+def copy_to_clipboard(text: str) -> None:
+    """Copy text to the system clipboard."""
+    if sys.platform == "darwin":
+        subprocess.run(["pbcopy"], input=text, text=True, check=False)
+    elif sys.platform == "win32":
+        subprocess.run(["clip"], input=text, text=True, check=False)
+    else:
+        for cmd in (["wl-copy"], ["xclip", "-selection", "clipboard"]):
+            try:
+                subprocess.run(cmd, input=text, text=True, check=True)
+                return
+            except FileNotFoundError, subprocess.CalledProcessError:
+                continue
+        subprocess.run(
+            ["xclip", "-selection", "clipboard"], input=text, text=True, check=False
+        )

--- a/src/mini_agent/cli/display/completion.py
+++ b/src/mini_agent/cli/display/completion.py
@@ -15,6 +15,7 @@ COMMANDS = {
     "/new": "Start a new session",
     "/resume": "Resume a previous session",
     "/model": "Select a model",
+    "/copy": "Copy the last assistant response to clipboard",
     "/status": "Show current session configuration and token usage",
     "/exit": "exit the session",
 }

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -11,6 +11,7 @@ from ..config import (
     REASONING_EFFORT_LEVELS,
     config,
 )
+from .clipboard import copy_to_clipboard, extract_text_content
 from .display import (
     ACCENT_COLOR,
     clear_prompt_line,
@@ -115,6 +116,21 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
             continue
         if command == "/status":
             print_box(console, format_status_report(current_session_id))
+            print()
+            attached_images.clear()
+            continue
+        if command == "/copy":
+            last_text: str | None = None
+            for message in reversed(history):
+                if message["role"] == "assistant":
+                    last_text = extract_text_content(message["content"])
+                    if last_text:
+                        break
+            if last_text:
+                copy_to_clipboard(last_text)
+                print("Copied to clipboard.")
+            else:
+                print("No assistant message to copy.")
             print()
             attached_images.clear()
             continue

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -11,7 +11,7 @@ from ..config import (
     REASONING_EFFORT_LEVELS,
     config,
 )
-from .clipboard import copy_to_clipboard, extract_text_content
+from .clipboard import copy_last_assistant_text
 from .display import (
     ACCENT_COLOR,
     clear_prompt_line,
@@ -120,17 +120,7 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
             attached_images.clear()
             continue
         if command == "/copy":
-            last_text: str | None = None
-            for message in reversed(history):
-                if message["role"] == "assistant":
-                    last_text = extract_text_content(message["content"])
-                    if last_text:
-                        break
-            if last_text:
-                copy_to_clipboard(last_text)
-                print("Copied to clipboard.")
-            else:
-                print("No assistant message to copy.")
+            copy_last_assistant_text(history)
             print()
             attached_images.clear()
             continue


### PR DESCRIPTION
## Description

Add a `/copy` command to the interactive CLI that copies the last assistant response to the system clipboard. This makes it easy to extract and reuse AI-generated content without manual selection.

- Refactored `extract_text_content` in `clipboard.py` for better robustness
- Added `copy_to_clipboard` utility supporting macOS (pbcopy), Windows (clip), and Linux (wl-copy/xclip)
- Registered `/copy` in the help menu
- Added the `/copy` command handler in the main interactive loop

Closes https://github.com/kowyo/mini-agent/issues/51

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Additional Notes

The clipboard utility is implemented in a cross-platform manner, falling back gracefully if no clipboard tool is available.
