### PR TITLE
refactor: remove safe_path and related path-guard logic

### DIFF
--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -8,6 +8,11 @@ from ..config import WORKDIR
 from .skills import skill_loader
 
 
+def _resolve_path(path_str: str) -> Path:
+    path = Path(path_str)
+    return path.resolve() if path.is_absolute() else (WORKDIR / path_str).resolve()
+
+
 def run_bash(command: str) -> str:
     dangerous = ["rm -rf /", "sudo", "shutdown", "reboot", "> /dev/"]
     if any(token in command for token in dangerous):
@@ -33,7 +38,7 @@ def run_bash(command: str) -> str:
 
 def run_read(path: str, limit: int | None = None) -> str:
     try:
-        text = Path(path).read_text()
+        text = _resolve_path(path).read_text()
         lines = text.splitlines()
         if limit and limit < len(lines):
             remaining = len(lines) - limit
@@ -45,7 +50,7 @@ def run_read(path: str, limit: int | None = None) -> str:
 
 def run_write(path: str, content: str) -> str:
     try:
-        file_path = Path(path)
+        file_path = _resolve_path(path)
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text(content)
         return f"Wrote {len(content)} bytes to {path}"
@@ -55,7 +60,7 @@ def run_write(path: str, content: str) -> str:
 
 def run_edit(path: str, old_text: str, new_text: str) -> str:
     try:
-        file_path = Path(path)
+        file_path = _resolve_path(path)
         content = file_path.read_text()
         if old_text not in content:
             return f"Error: Text not found in {path}"

--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -8,16 +8,6 @@ from ..config import WORKDIR
 from .skills import skill_loader
 
 
-def safe_path(path_str: str) -> Path:
-    path = Path(path_str)
-    path = path.resolve() if path.is_absolute() else (WORKDIR / path_str).resolve()
-
-    if path.is_relative_to(WORKDIR) or path.is_relative_to(Path("/tmp")):
-        return path
-
-    raise ValueError(f"Path escapes workspace: {path_str}")
-
-
 def run_bash(command: str) -> str:
     dangerous = ["rm -rf /", "sudo", "shutdown", "reboot", "> /dev/"]
     if any(token in command for token in dangerous):
@@ -43,7 +33,7 @@ def run_bash(command: str) -> str:
 
 def run_read(path: str, limit: int | None = None) -> str:
     try:
-        text = safe_path(path).read_text()
+        text = Path(path).read_text()
         lines = text.splitlines()
         if limit and limit < len(lines):
             remaining = len(lines) - limit
@@ -55,7 +45,7 @@ def run_read(path: str, limit: int | None = None) -> str:
 
 def run_write(path: str, content: str) -> str:
     try:
-        file_path = safe_path(path)
+        file_path = Path(path)
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text(content)
         return f"Wrote {len(content)} bytes to {path}"
@@ -65,7 +55,7 @@ def run_write(path: str, content: str) -> str:
 
 def run_edit(path: str, old_text: str, new_text: str) -> str:
     try:
-        file_path = safe_path(path)
+        file_path = Path(path)
         content = file_path.read_text()
         if old_text not in content:
             return f"Error: Text not found in {path}"

--- a/src/mini_agent/cli/display/printing.py
+++ b/src/mini_agent/cli/display/printing.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from html import escape
+from pathlib import Path
 from typing import cast
 
 from anthropic.types import MessageParam
@@ -10,7 +11,6 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.text import Text
 
-from ...agent.tools import safe_path
 from ...config import DISTRIBUTION_NAME, DISTRIBUTION_VERSION, config
 from ..clipboard import extract_text_content
 from .box import print_box
@@ -115,7 +115,7 @@ def print_tool_result(name: str, input_data: dict[str, object], output: str) -> 
             return
         old_text = cast(str, input_data["old_text"])
         new_text = cast(str, input_data["new_text"])
-        edited_content = safe_path(path).read_text()
+        edited_content = Path(path).read_text()
         pos = edited_content.find(new_text)
         start_line = edited_content[:pos].count("\n") + 1 if pos != -1 else 1
         diff = format_edit_diff(old_text, new_text, start_line)


### PR DESCRIPTION
## Description

Remove `safe_path` and its related workspace-confinement logic from the core tool handlers.

The `safe_path` function resolved file paths and rejected any that escaped `WORKDIR` or `/tmp`. This was an attempt at static permission enforcement, but modern frontier models write and chain dynamic scripts, making such static path validation a false sense of security. Permissions and access control are better handled at the plugin/policy level rather than baked into core tools.

Refs https://github.com/kowyo/mini-agent/issues/52

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change that removes dead/complex logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Test

- `make check` — ruff format and lint pass
- `make type-check` — type checks pass
