### PR TITLE
feat(agent): preserve partial bash output on Ctrl-C and stop agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
   build:
     needs: lint
     strategy:
+      fail-fast: true
       matrix:
         include:
           - os: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     needs: lint
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,2 @@
-After modifying code, run `make check` and `make type-check`. Fix any failures before concluding the turn.
+- After modifying code, run `make check` and `make type-check`. Fix any failures before concluding the turn.
+- Do not write comments or docstrings.

--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -11,7 +11,7 @@ from ..cli.models import get_max_output_tokens
 from ..cli.token import Usage, token_tracker
 from ..config import client, config
 from .system_prompt import SYSTEM
-from .tools import TOOL_HANDLERS, TOOLS
+from .tools import TOOL_HANDLERS, TOOLS, BashInterruptedError
 
 console = Console()
 
@@ -80,37 +80,62 @@ def agent_loop(messages: list[MessageParam]) -> None:
             )
 
             results = []
-            for block in response.content:
-                if isinstance(block, ToolUseBlock):
-                    if working_status is None:
-                        working_status = console.status("Working")
-                        working_status.start()
-                    handler = TOOL_HANDLERS.get(block.name)
-                    print_tool_start(block.name, block.input)
-                    output = (
-                        handler(**block.input)
-                        if handler
-                        else f"Unknown tool: {block.name}"
-                    )
-                    if working_status is not None:
-                        working_status.stop()
-                        working_status = None
-                    print_tool_result(block.name, block.input, output)
-                    results.append(
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": block.id,
-                            "content": output,
-                        }
-                    )
+            try:
+                for block in response.content:
+                    if isinstance(block, ToolUseBlock):
+                        if working_status is None:
+                            working_status = console.status("Working")
+                            working_status.start()
+                        handler = TOOL_HANDLERS.get(block.name)
+                        print_tool_start(block.name, block.input)
+                        interrupted = False
+                        try:
+                            output = (
+                                handler(**block.input)
+                                if handler
+                                else f"Unknown tool: {block.name}"
+                            )
+                        except BashInterruptedError as e:
+                            output = e.partial_output
+                            interrupted = True
+                        if working_status is not None:
+                            working_status.stop()
+                            working_status = None
+                        results.append(
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": block.id,
+                                "content": output,
+                            }
+                        )
+                        print_tool_result(block.name, block.input, output)
+                        if interrupted:
+                            raise KeyboardInterrupt
+            except KeyboardInterrupt:
+                completed_ids = {r["tool_use_id"] for r in results}
+                for remaining in response.content:
+                    if (
+                        isinstance(remaining, ToolUseBlock)
+                        and remaining.id not in completed_ids
+                    ):
+                        results.append(
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": remaining.id,
+                                "content": "Command aborted",
+                            }
+                        )
+                if results:
+                    messages.append({"role": "user", "content": results})
+                raise
 
             if working_status is not None:
                 working_status.stop()
 
+            if results:
+                messages.append({"role": "user", "content": results})
             if response.stop_reason != "tool_use":
                 return
-
-            messages.append({"role": "user", "content": results})
 
     except KeyboardInterrupt:
         print("\r", end="", flush=True)

--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -59,7 +59,11 @@ def run_bash(command: str) -> str:
             proc.kill()
         reader.join(timeout=1)
         output = "".join(output_parts).strip()
-        partial = (output + "\n\nCommand aborted") if output else "Command aborted"
+        partial = (
+            (output[:MAX_OUTPUT] + "\n\nCommand aborted")
+            if output
+            else "Command aborted"
+        )
         raise BashInterruptedError(partial) from None
 
     if reader.is_alive():
@@ -67,7 +71,7 @@ def run_bash(command: str) -> str:
         reader.join(timeout=1)
         output = "".join(output_parts).strip()
         suffix = f"Command timed out after {TIMEOUT_SECONDS} seconds"
-        return (output + "\n\n" + suffix if output else suffix)[:MAX_OUTPUT]
+        return output[:MAX_OUTPUT] + "\n\n" + suffix if output else suffix
 
     exit_code = proc.wait()
     output = "".join(output_parts).strip()

--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -1,3 +1,5 @@
+import os
+import signal
 import subprocess
 import threading
 from pathlib import Path
@@ -36,6 +38,7 @@ def run_bash(command: str) -> str:
         text=True,
         encoding="utf-8",
         errors="replace",
+        start_new_session=True,
     )
 
     stdout = proc.stdout
@@ -52,11 +55,11 @@ def run_bash(command: str) -> str:
     try:
         reader.join(timeout=TIMEOUT_SECONDS)
     except KeyboardInterrupt:
-        proc.terminate()
+        os.killpg(proc.pid, signal.SIGTERM)
         try:
             proc.wait(timeout=2)
         except subprocess.TimeoutExpired:
-            proc.kill()
+            os.killpg(proc.pid, signal.SIGKILL)
         reader.join(timeout=1)
         output = "".join(output_parts).strip()
         partial = (
@@ -67,7 +70,7 @@ def run_bash(command: str) -> str:
         raise BashInterruptedError(partial) from None
 
     if reader.is_alive():
-        proc.kill()
+        os.killpg(proc.pid, signal.SIGKILL)
         reader.join(timeout=1)
         output = "".join(output_parts).strip()
         suffix = f"Command timed out after {TIMEOUT_SECONDS} seconds"

--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import subprocess
+import sys
 import threading
 from pathlib import Path
 from typing import Any
@@ -17,6 +18,20 @@ MAX_OUTPUT = 50000
 class BashInterruptedError(Exception):
     def __init__(self, partial_output: str) -> None:
         self.partial_output = partial_output
+
+
+def _kill_process_tree(proc: subprocess.Popen) -> None:
+    if sys.platform == "win32":
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+            capture_output=True,
+        )
+    else:
+        os.killpg(proc.pid, signal.SIGTERM)
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            os.killpg(proc.pid, signal.SIGKILL)
 
 
 def _resolve_path(path_str: str) -> Path:
@@ -55,11 +70,7 @@ def run_bash(command: str) -> str:
     try:
         reader.join(timeout=TIMEOUT_SECONDS)
     except KeyboardInterrupt:
-        os.killpg(proc.pid, signal.SIGTERM)
-        try:
-            proc.wait(timeout=2)
-        except subprocess.TimeoutExpired:
-            os.killpg(proc.pid, signal.SIGKILL)
+        _kill_process_tree(proc)
         reader.join(timeout=1)
         output = "".join(output_parts).strip()
         partial = (
@@ -70,7 +81,7 @@ def run_bash(command: str) -> str:
         raise BashInterruptedError(partial) from None
 
     if reader.is_alive():
-        os.killpg(proc.pid, signal.SIGKILL)
+        _kill_process_tree(proc)
         reader.join(timeout=1)
         output = "".join(output_parts).strip()
         suffix = f"Command timed out after {TIMEOUT_SECONDS} seconds"

--- a/src/mini_agent/agent/tools.py
+++ b/src/mini_agent/agent/tools.py
@@ -1,4 +1,5 @@
 import subprocess
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -6,6 +7,14 @@ from anthropic.types import ToolParam
 
 from ..config import WORKDIR
 from .skills import skill_loader
+
+TIMEOUT_SECONDS = 120
+MAX_OUTPUT = 50000
+
+
+class BashInterruptedError(Exception):
+    def __init__(self, partial_output: str) -> None:
+        self.partial_output = partial_output
 
 
 def _resolve_path(path_str: str) -> Path:
@@ -18,22 +27,53 @@ def run_bash(command: str) -> str:
     if any(token in command for token in dangerous):
         return "Error: Dangerous command blocked"
 
-    try:
-        result = subprocess.run(
-            command,
-            shell=True,
-            cwd=WORKDIR,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=120,
-        )
-    except subprocess.TimeoutExpired:
-        return "Error: Timeout (120s)"
+    proc = subprocess.Popen(
+        command,
+        shell=True,
+        cwd=WORKDIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
 
-    output = (result.stdout + result.stderr).strip()
-    return output[:50000] if output else "(no output)"
+    stdout = proc.stdout
+    assert stdout is not None
+    output_parts: list[str] = []
+
+    def _read() -> None:
+        for line in stdout:
+            output_parts.append(line)
+
+    reader = threading.Thread(target=_read, daemon=True)
+    reader.start()
+
+    try:
+        reader.join(timeout=TIMEOUT_SECONDS)
+    except KeyboardInterrupt:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        reader.join(timeout=1)
+        output = "".join(output_parts).strip()
+        partial = (output + "\n\nCommand aborted") if output else "Command aborted"
+        raise BashInterruptedError(partial) from None
+
+    if reader.is_alive():
+        proc.kill()
+        reader.join(timeout=1)
+        output = "".join(output_parts).strip()
+        suffix = f"Command timed out after {TIMEOUT_SECONDS} seconds"
+        return (output + "\n\n" + suffix if output else suffix)[:MAX_OUTPUT]
+
+    exit_code = proc.wait()
+    output = "".join(output_parts).strip()
+    if not output:
+        return f"(no output)\n\nCommand exited with code {exit_code}"
+    return output[:MAX_OUTPUT]
 
 
 def run_read(path: str, limit: int | None = None) -> str:
@@ -43,7 +83,7 @@ def run_read(path: str, limit: int | None = None) -> str:
         if limit and limit < len(lines):
             remaining = len(lines) - limit
             lines = lines[:limit] + [f"... ({remaining} more lines)"]
-        return "\n".join(lines)[:50000]
+        return "\n".join(lines)[:MAX_OUTPUT]
     except Exception as exc:
         return f"Error: {exc}"
 


### PR DESCRIPTION
## Description

Preserve partial bash output when the user presses Ctrl-C and stop the agent. This ensures any output produced by the bash tool before interruption is not lost.

closes https://github.com/kowyo/mini-agent/issues/14

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test

Verified that partial output is preserved when interrupting a long-running bash command with Ctrl-C.
