### PR TITLE
fix: handle token limit fetch failures gracefully

### DIFF
--- a/src/mini_agent/cli/models.py
+++ b/src/mini_agent/cli/models.py
@@ -3,19 +3,12 @@ import urllib.request
 from functools import lru_cache
 from urllib.parse import urlparse
 
-from ..config import REASONING_EFFORT_LEVELS, client, config
+from ..config import CONFIG_DIR, REASONING_EFFORT_LEVELS, client, config
 from .display import clear_prompt_line
 from .display.picker import select_from_list
 
 
-@lru_cache(maxsize=1)
-def _fetch_limits() -> dict[str, dict]:
-    req = urllib.request.Request(
-        "https://models.dev/api.json",
-        headers={"User-Agent": "Mozilla/5.0"},
-    )
-    with urllib.request.urlopen(req, timeout=5) as resp:
-        data = json.loads(resp.read())
+def _parse_limits(data: dict) -> dict[str, dict]:
     limits: dict[str, dict] = {}
     for provider in data.values():
         for model_id, model in provider.get("models", {}).items():
@@ -28,6 +21,36 @@ def _fetch_limits() -> dict[str, dict]:
                 or None,
             }
     return limits
+
+
+_MODELS_CACHE_PATH = CONFIG_DIR / "models.json"
+
+
+def _load_cached_limits() -> dict[str, dict]:
+    with _MODELS_CACHE_PATH.open() as f:
+        data = json.load(f)
+    return _parse_limits(data)
+
+
+def _save_cache(data: dict) -> None:
+    _MODELS_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with _MODELS_CACHE_PATH.open("w") as f:
+        json.dump(data, f, indent=2)
+
+
+@lru_cache(maxsize=1)
+def _fetch_limits() -> dict[str, dict]:
+    req = urllib.request.Request(
+        "https://models.dev/api.json",
+        headers={"User-Agent": "Mozilla/5.0"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+        _save_cache(data)
+        return _parse_limits(data)
+    except Exception:
+        return _load_cached_limits()
 
 
 def get_max_context_tokens(model_id: str) -> int | None:

--- a/src/mini_agent/cli/models.py
+++ b/src/mini_agent/cli/models.py
@@ -1,6 +1,5 @@
 import json
 import urllib.request
-from functools import lru_cache
 from urllib.parse import urlparse
 
 from ..config import CONFIG_DIR, REASONING_EFFORT_LEVELS, client, config
@@ -23,48 +22,55 @@ def _parse_limits(data: dict) -> dict[str, dict]:
     return limits
 
 
-_MODELS_CACHE_PATH = CONFIG_DIR / "models.json"
+class _LimitsProvider:
+    def __init__(self) -> None:
+        self._cache_path = CONFIG_DIR / "models.json"
+        self._cache: dict[str, dict] | None = None
+
+    def _load(self) -> dict[str, dict]:
+        if self._cache is None:
+            try:
+                with self._cache_path.open() as f:
+                    self._cache = _parse_limits(json.load(f))
+            except FileNotFoundError, json.JSONDecodeError:
+                self._cache = {}
+        return self._cache
+
+    def get(self, model_id: str, key: str) -> int | None:
+        return self._load().get(model_id, {}).get(key)
+
+    def get_entry(self, model_id: str) -> dict:
+        return self._load().get(model_id, {})
+
+    def refresh(self) -> None:
+        try:
+            req = urllib.request.Request(
+                "https://models.dev/api.json",
+                headers={"User-Agent": "Mozilla/5.0"},
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                data = json.loads(resp.read())
+            self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._cache_path.open("w") as f:
+                json.dump(data, f)
+            self._cache = _parse_limits(data)
+        except OSError, json.JSONDecodeError:
+            pass
 
 
-def _load_cached_limits() -> dict[str, dict]:
-    with _MODELS_CACHE_PATH.open() as f:
-        data = json.load(f)
-    return _parse_limits(data)
-
-
-def _save_cache(data: dict) -> None:
-    _MODELS_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with _MODELS_CACHE_PATH.open("w") as f:
-        json.dump(data, f, indent=2)
-
-
-@lru_cache(maxsize=1)
-def _fetch_limits() -> dict[str, dict]:
-    req = urllib.request.Request(
-        "https://models.dev/api.json",
-        headers={"User-Agent": "Mozilla/5.0"},
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            data = json.loads(resp.read())
-        _save_cache(data)
-        return _parse_limits(data)
-    except Exception:
-        return _load_cached_limits()
+_limits = _LimitsProvider()
 
 
 def get_max_context_tokens(model_id: str) -> int | None:
-    try:
-        return _fetch_limits().get(model_id, {}).get("context")
-    except Exception:
-        return None
+    return _limits.get(model_id, "context")
 
 
 def get_max_output_tokens(model_id: str) -> int | None:
-    try:
-        return _fetch_limits().get(model_id, {}).get("output")
-    except Exception:
-        return None
+    return _limits.get(model_id, "output")
+
+
+def refresh_limits() -> None:
+    _limits.refresh()
 
 
 def _fetch_models_sdk() -> list[str]:
@@ -110,9 +116,9 @@ def fetch_models() -> list[str]:
 def format_model(model_id: str) -> str:
     parts = [model_id]
     try:
-        limits = _fetch_limits().get(model_id, {})
-        context = limits.get("context")
-        output = limits.get("output")
+        entry = _limits.get_entry(model_id)
+        context = entry.get("context")
+        output = entry.get("output")
         if context is not None:
             parts.append(f"in:{context:,}")
         if output is not None:
@@ -168,6 +174,7 @@ def select_reasoning_effort() -> str | None:
 
 
 def prompt_model() -> None:
+    refresh_limits()
     try:
         model_ids = fetch_models()
     except Exception as e:

--- a/src/mini_agent/cli/models.py
+++ b/src/mini_agent/cli/models.py
@@ -33,16 +33,14 @@ def _fetch_limits() -> dict[str, dict]:
 def get_max_context_tokens(model_id: str) -> int | None:
     try:
         return _fetch_limits().get(model_id, {}).get("context")
-    except Exception as e:
-        print(f"Failed to fetch context token limit: {e}")
+    except Exception:
         return None
 
 
 def get_max_output_tokens(model_id: str) -> int | None:
     try:
         return _fetch_limits().get(model_id, {}).get("output")
-    except Exception as e:
-        print(f"Failed to fetch output token limit: {e}")
+    except Exception:
         return None
 
 

--- a/src/mini_agent/cli/models.py
+++ b/src/mini_agent/cli/models.py
@@ -7,42 +7,35 @@ from .display import clear_prompt_line
 from .display.picker import select_from_list
 
 
-def _parse_limits(data: dict) -> dict[str, dict]:
-    limits: dict[str, dict] = {}
-    for provider in data.values():
-        for model_id, model in provider.get("models", {}).items():
-            limit = model.get("limit", {})
-            existing = limits.get(model_id, {})
-            limits[model_id] = {
-                "context": max(existing.get("context") or 0, limit.get("context") or 0)
-                or None,
-                "output": max(existing.get("output") or 0, limit.get("output") or 0)
-                or None,
-            }
-    return limits
-
-
-class _LimitsProvider:
+class _ModelInfo:
     def __init__(self) -> None:
         self._cache_path = CONFIG_DIR / "models.json"
         self._cache: dict[str, dict] | None = None
 
-    def _load(self) -> dict[str, dict]:
+    def _load_cache(self) -> dict[str, dict]:
+        """Load the cache from disk, returning an empty dict on failure."""
         if self._cache is None:
             try:
                 with self._cache_path.open() as f:
-                    self._cache = _parse_limits(json.load(f))
+                    self._cache = json.load(f)
             except FileNotFoundError, json.JSONDecodeError:
                 self._cache = {}
         return self._cache
 
-    def get(self, model_id: str, key: str) -> int | None:
-        return self._load().get(model_id, {}).get(key)
+    def get_best_limit(self, model_id: str, key: str) -> int | None:
+        """Return the maximum value for *key* (e.g. 'context' or 'output') across all providers for a given model."""
+        best = None
+        for provider in self._load_cache().values():
+            model = provider.get("models", {}).get(model_id)
+            if model is None:
+                continue
+            value = model.get("limit", {}).get(key)
+            if value is not None and (best is None or value > best):
+                best = value
+        return best
 
-    def get_entry(self, model_id: str) -> dict:
-        return self._load().get(model_id, {})
-
-    def refresh(self) -> None:
+    def refresh_cache(self) -> None:
+        """Fetch the latest model data from the remote API and update the local cache."""
         try:
             req = urllib.request.Request(
                 "https://models.dev/api.json",
@@ -53,24 +46,24 @@ class _LimitsProvider:
             self._cache_path.parent.mkdir(parents=True, exist_ok=True)
             with self._cache_path.open("w") as f:
                 json.dump(data, f)
-            self._cache = _parse_limits(data)
+            self._cache = data
         except OSError, json.JSONDecodeError:
             pass
 
 
-_limits = _LimitsProvider()
+_model_info = _ModelInfo()
 
 
 def get_max_context_tokens(model_id: str) -> int | None:
-    return _limits.get(model_id, "context")
+    return _model_info.get_best_limit(model_id, "context")
 
 
 def get_max_output_tokens(model_id: str) -> int | None:
-    return _limits.get(model_id, "output")
+    return _model_info.get_best_limit(model_id, "output")
 
 
-def refresh_limits() -> None:
-    _limits.refresh()
+def refresh_model_limits() -> None:
+    _model_info.refresh_cache()
 
 
 def _fetch_models_sdk() -> list[str]:
@@ -116,9 +109,8 @@ def fetch_models() -> list[str]:
 def format_model(model_id: str) -> str:
     parts = [model_id]
     try:
-        entry = _limits.get_entry(model_id)
-        context = entry.get("context")
-        output = entry.get("output")
+        context = _model_info.get_best_limit(model_id, "context")
+        output = _model_info.get_best_limit(model_id, "output")
         if context is not None:
             parts.append(f"in:{context:,}")
         if output is not None:
@@ -174,7 +166,7 @@ def select_reasoning_effort() -> str | None:
 
 
 def prompt_model() -> None:
-    refresh_limits()
+    refresh_model_limits()
     try:
         model_ids = fetch_models()
     except Exception as e:


### PR DESCRIPTION
## Description

Fix token limit fetch errors corrupting prompt input and add offline fallback.

## Type of change

- [x] Bug fix
- [x] New feature

## Test

Tested by:
1. Breaking the API URL to trigger network failures
2. Verifying error messages no longer appear in prompt input
3. Verifying fallback to cached `models.json` works when offline
4. Verifying error reason is displayed in agent loop with proper styling

---

Assisted-by: mini-agent:deepseek-v4-flash
