### PR TITLE
feat(toolbar): display cache read/write tokens separately

### DIFF
--- a/src/mini_agent/cli/display/toolbar.py
+++ b/src/mini_agent/cli/display/toolbar.py
@@ -9,7 +9,12 @@ from .picker import LIGHT_HINT_STYLE
 
 
 def _format_token_right(total: Usage, last_round: Usage | None) -> str:
-    right = f"↑{total.total_input_tokens} ↓{total.output_tokens}"
+    parts = [f"↑{total.input_tokens}", f"↓{total.output_tokens}"]
+    if total.cache_read_input_tokens:
+        parts.append(f"R{total.cache_read_input_tokens}")
+    if total.cache_creation_input_tokens:
+        parts.append(f"W{total.cache_creation_input_tokens}")
+    right = " ".join(parts)
     context_limit = get_max_context_tokens(config.get_model())
     if context_limit and last_round is not None:
         used_tokens = last_round.total_input_tokens + last_round.output_tokens

--- a/src/mini_agent/cli/display/toolbar.py
+++ b/src/mini_agent/cli/display/toolbar.py
@@ -8,18 +8,33 @@ from ..token import Usage, token_tracker
 from .picker import LIGHT_HINT_STYLE
 
 
+def _format_tokens(count: int) -> str:
+    if count < 1000:
+        return str(count)
+    if count < 10000:
+        return f"{count / 1000:.1f}k"
+    if count < 1_000_000:
+        return f"{round(count / 1000)}k"
+    if count < 10_000_000:
+        return f"{count / 1_000_000:.1f}M"
+    return f"{round(count / 1_000_000)}M"
+
+
 def _format_token_right(total: Usage, last_round: Usage | None) -> str:
-    parts = [f"↑{total.input_tokens}", f"↓{total.output_tokens}"]
+    parts = [
+        f"↑{_format_tokens(total.input_tokens)}",
+        f"↓{_format_tokens(total.output_tokens)}",
+    ]
     if total.cache_read_input_tokens:
-        parts.append(f"R{total.cache_read_input_tokens}")
+        parts.append(f"R{_format_tokens(total.cache_read_input_tokens)}")
     if total.cache_creation_input_tokens:
-        parts.append(f"W{total.cache_creation_input_tokens}")
+        parts.append(f"W{_format_tokens(total.cache_creation_input_tokens)}")
     right = " ".join(parts)
     context_limit = get_max_context_tokens(config.get_model())
     if context_limit and last_round is not None:
         used_tokens = last_round.total_input_tokens + last_round.output_tokens
         percent = min(100.0, (used_tokens / context_limit) * 100)
-        right = f"{right} {percent:.1f}%"
+        right = f"{right} {percent:.1f}%/{_format_tokens(context_limit)}"
     return f"{right}  "
 
 

--- a/src/mini_agent/cli/token.py
+++ b/src/mini_agent/cli/token.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class Usage:
-    input_tokens: int
-    cache_creation_input_tokens: int
-    cache_read_input_tokens: int
+    input_tokens: int  # tokens after the last cache breakpoint
+    cache_creation_input_tokens: int  # tokens written to cache
+    cache_read_input_tokens: int  # tokens read from cache
     output_tokens: int
 
     @property


### PR DESCRIPTION
## Description

Split the aggregated `↑total_input_tokens` in the toolbar into individual components: input (`↑`), output (`↓`), cache read (`R`), and cache write (`W`). Zero-valued cache metrics are hidden to keep the display clean.

Also added inline comments to the `Usage` dataclass fields for clarity.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test

`make check` and `make type-check` both pass.

---

Assisted-by: mini-agent:deepseek-v4-flash
