### PR TITLE
fix: session replay shows all message types + session storage refactor

### DIFF
--- a/src/mini_agent/cli/display/printing.py
+++ b/src/mini_agent/cli/display/printing.py
@@ -15,7 +15,11 @@ from ...config import DISTRIBUTION_NAME, DISTRIBUTION_VERSION, config
 from ..clipboard import extract_text_content
 from .box import print_box
 from .diff import format_edit_diff
-from .theme import LIGHT_HINT_STYLE_RICH, PROMPT_TOOLKIT_ACCENT_COLOR
+from .theme import (
+    LIGHT_HINT_STYLE_RICH,
+    PROMPT_TOOLKIT_ACCENT_COLOR,
+    THINKING_STYLE_RICH,
+)
 
 console = Console()
 
@@ -104,7 +108,7 @@ def print_session_history(history: list[MessageParam]) -> None:
                     thinking_text = str(block.get("thinking", "")).strip()
                     if thinking_text:
                         console.print(
-                            Markdown(thinking_text, style=LIGHT_HINT_STYLE_RICH)
+                            Markdown(thinking_text, style=THINKING_STYLE_RICH)
                         )
                         print()
                 elif block.get("type") == "tool_use":

--- a/src/mini_agent/cli/display/printing.py
+++ b/src/mini_agent/cli/display/printing.py
@@ -80,7 +80,6 @@ def print_session_history(history: list[MessageParam]) -> None:
                             print()
                         else:
                             print_tool_result(name, input_data, output)
-                    continue
 
             text = extract_text_content(content)
             if text:

--- a/src/mini_agent/cli/display/printing.py
+++ b/src/mini_agent/cli/display/printing.py
@@ -48,10 +48,36 @@ def print_welcome_banner() -> None:
 def print_session_history(history: list[MessageParam]) -> None:
     clear_terminal()
     print_welcome_banner()
+
+    tool_registry: dict[str, tuple[str, dict[str, object]]] = {}
+
     for message in history:
         content = message["content"]
 
         if message["role"] == "user":
+            if isinstance(content, list):
+                tool_results = [
+                    b
+                    for b in content
+                    if isinstance(b, dict) and b.get("type") == "tool_result"
+                ]
+                if tool_results:
+                    for block in tool_results:
+                        tool_use_id = str(block.get("tool_use_id", ""))
+                        name, input_data = tool_registry.get(
+                            tool_use_id, ("unknown", {})
+                        )
+                        output = str(block.get("content", ""))
+                        if name == "bash" and output:
+                            for line in output.splitlines():
+                                text = Text.from_ansi(line.rstrip("\n\r"))
+                                text.stylize(LIGHT_HINT_STYLE_RICH)
+                                console.print(text)
+                            print()
+                        else:
+                            print_tool_result(name, input_data, output)
+                    continue
+
             text = extract_text_content(content)
             if text:
                 lines = text.splitlines()
@@ -67,11 +93,27 @@ def print_session_history(history: list[MessageParam]) -> None:
 
         if message["role"] == "assistant" and isinstance(content, list):
             for block in content:
-                if isinstance(block, dict) and block.get("type") == "text":
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") == "text":
                     text = str(block.get("text", "")).strip()
                     if text:
                         console.print(Markdown(text))
                         print()
+                elif block.get("type") == "thinking":
+                    thinking_text = str(block.get("thinking", "")).strip()
+                    if thinking_text:
+                        console.print(
+                            Markdown(thinking_text, style=LIGHT_HINT_STYLE_RICH)
+                        )
+                        print()
+                elif block.get("type") == "tool_use":
+                    name = str(block.get("name", "unknown"))
+                    input_data = cast(dict[str, object], block.get("input", {}))
+                    tool_use_id = str(block.get("id", ""))
+                    if tool_use_id:
+                        tool_registry[tool_use_id] = (name, input_data)
+                    print_tool_start(name, input_data)
 
 
 def print_tool_start(name: str, input_data: dict[str, object]) -> None:

--- a/src/mini_agent/cli/display/stream.py
+++ b/src/mini_agent/cli/display/stream.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.live import Live
 from rich.markdown import Markdown
 
-from .theme import LIGHT_HINT_STYLE_RICH
+from .theme import THINKING_STYLE_RICH
 
 console = Console()
 
@@ -32,7 +32,7 @@ def display_stream_events(stream: anthropic.lib.streaming.MessageStream) -> None
                 if isinstance(delta, TextDelta):
                     chunk, style = delta.text, None
                 elif isinstance(delta, ThinkingDelta):
-                    chunk, style = delta.thinking, LIGHT_HINT_STYLE_RICH
+                    chunk, style = delta.thinking, THINKING_STYLE_RICH
                 else:
                     continue
                 text += chunk

--- a/src/mini_agent/cli/display/theme.py
+++ b/src/mini_agent/cli/display/theme.py
@@ -4,6 +4,7 @@ PROMPT_TOOLKIT_ACCENT_COLOR = "ansicyan"
 SELECTED_STYLE = "bold"
 LIGHT_HINT_STYLE = "fg:#888888"
 LIGHT_HINT_STYLE_RICH = "dim"
+THINKING_STYLE_RICH = "dim italic"
 
 RED_BG = "\x1b[48;5;224m\x1b[30m"
 GREEN_BG = "\x1b[48;5;194m\x1b[30m"

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -46,9 +46,8 @@ def _run_non_interactive(prompt: str) -> None:
     session_id = session_manager.new_id()
     history_len = len(history)
     agent_loop(history)
-    usage = token_tracker.get()
-    if len(history) > history_len and usage is not None:
-        session_manager.save(session_id, history, usage)
+    if len(history) > history_len and token_tracker.get() is not None:
+        session_manager.save(session_id, history, token_tracker.rounds)
 
 
 def _run_interactive(prompt: str | None = None, session_id: str | None = None) -> None:
@@ -70,7 +69,7 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
             sent_image_count[0] = count_images_in_history(history)
             next_indicator[0] = max_indicator_in_history(history) + 1
             print_session_history(chosen.history)
-            token_tracker.restore(chosen.last_usage)
+            token_tracker.restore(chosen.round_usages)
         except StopIteration:
             print("Session ID not found.\n")
 
@@ -132,9 +131,8 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
 
         if len(history) <= history_len:
             continue
-        usage = token_tracker.get()
-        if usage is not None:
-            session_manager.save(current_session_id, history, usage)
+        if token_tracker.get() is not None:
+            session_manager.save(current_session_id, history, token_tracker.rounds)
 
     if session_manager.exists(current_session_id):
         usage_report = format_usage_report(token_tracker.get())

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -47,7 +47,7 @@ def _run_non_interactive(prompt: str) -> None:
     history_len = len(history)
     agent_loop(history)
     if len(history) > history_len and token_tracker.get() is not None:
-        session_manager.save(session_id, history, token_tracker.rounds)
+        session_manager.save(session_id, history, token_tracker.round_usages)
 
 
 def _run_interactive(prompt: str | None = None, session_id: str | None = None) -> None:
@@ -132,7 +132,9 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
         if len(history) <= history_len:
             continue
         if token_tracker.get() is not None:
-            session_manager.save(current_session_id, history, token_tracker.rounds)
+            session_manager.save(
+                current_session_id, history, token_tracker.round_usages
+            )
 
     if session_manager.exists(current_session_id):
         usage_report = format_usage_report(token_tracker.get())

--- a/src/mini_agent/cli/main.py
+++ b/src/mini_agent/cli/main.py
@@ -1,5 +1,4 @@
 import argparse
-import uuid
 
 from anthropic.types import MessageParam
 from rich.console import Console
@@ -27,11 +26,9 @@ from .image_messages import (
 from .models import prompt_model
 from .prompt_session import build_session
 from .sessions import (
-    list_sessions,
+    SessionManager,
     print_session_history,
     prompt_resume,
-    save_session_history,
-    session_saved,
 )
 from .status import (
     format_status_report,
@@ -41,30 +38,30 @@ from .token import token_tracker
 
 console = Console()
 
+session_manager = SessionManager()
+
 
 def _run_non_interactive(prompt: str) -> None:
-    """Run the agent on a single prompt and exit (non-interactive mode)."""
     history: list[MessageParam] = [{"role": "user", "content": prompt}]
-    current_session_id = uuid.uuid4().hex
+    session_id = session_manager.new_id()
     history_len = len(history)
     agent_loop(history)
     usage = token_tracker.get()
     if len(history) > history_len and usage is not None:
-        save_session_history(current_session_id, history, usage)
+        session_manager.save(session_id, history, usage)
 
 
 def _run_interactive(prompt: str | None = None, session_id: str | None = None) -> None:
-    """Run the interactive TUI session."""
     print_welcome_banner()
     history: list[MessageParam] = []
-    current_session_id = uuid.uuid4().hex
+    current_session_id = session_manager.new_id()
     session, pre_run, attached_images, sent_image_count, next_indicator = build_session(
         prompt
     )
 
     if session_id is not None:
         current_session_id = session_id
-        sessions = list_sessions()
+        sessions = session_manager.list_sessions()
         try:
             chosen = next(
                 stored for stored in sessions if stored.session_id == current_session_id
@@ -96,7 +93,7 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
         print()
         if command == "/new":
             history.clear()
-            current_session_id = uuid.uuid4().hex
+            current_session_id = session_manager.new_id()
             sent_image_count[0] = 0
             next_indicator[0] = 1
             token_tracker.reset()
@@ -105,7 +102,9 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
             print_welcome_banner()
             continue
         if command == "/resume":
-            current_session_id, history, _ = prompt_resume(current_session_id, history)
+            current_session_id, history, _ = prompt_resume(
+                session_manager, current_session_id, history
+            )
             sent_image_count[0] = count_images_in_history(history)
             next_indicator[0] = max_indicator_in_history(history) + 1
             attached_images.clear()
@@ -135,9 +134,9 @@ def _run_interactive(prompt: str | None = None, session_id: str | None = None) -
             continue
         usage = token_tracker.get()
         if usage is not None:
-            save_session_history(current_session_id, history, usage)
+            session_manager.save(current_session_id, history, usage)
 
-    if session_saved(current_session_id):
+    if session_manager.exists(current_session_id):
         usage_report = format_usage_report(token_tracker.get())
         if usage_report:
             for line in usage_report:
@@ -205,7 +204,7 @@ def main() -> None:
 
     session_id: str | None = args.session_id
     if session_id == "__LATEST__":
-        sessions = list_sessions()
+        sessions = session_manager.list_sessions()
         if sessions:
             session_id = sessions[0].session_id
         else:

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -24,9 +24,9 @@ class StoredSession:
     round_usages: list[Usage]
 
 
-def serialize_content(content: str | Iterable[object]) -> str | list[object]:
+def serialize_content(content: str | Iterable[object]) -> list[object]:
     if isinstance(content, str):
-        return content
+        return [{"type": "text", "text": content}]
     serialized_blocks: list[object] = []
     for block in content:
         if isinstance(block, BaseModel):

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -23,19 +24,8 @@ class StoredSession:
     last_usage: Usage
 
 
-def session_path(session_id: str) -> Path:
-    return SESSION_DIR / f"{session_id}.jsonl"
-
-
-def session_saved(session_id: str) -> bool:
-    return session_path(session_id).exists()
-
-
-def ensure_session_dir() -> None:
-    SESSION_DIR.mkdir(parents=True, exist_ok=True)
-
-
 def serialize_content(content: str | Iterable[object]) -> str | list[object]:
+    """Serialize message content blocks for JSON output."""
     if isinstance(content, str):
         return content
     serialized_blocks: list[object] = []
@@ -49,92 +39,211 @@ def serialize_content(content: str | Iterable[object]) -> str | list[object]:
     return serialized_blocks
 
 
-def save_session_history(
-    session_id: str,
-    history: list[MessageParam],
-    last_usage: Usage,
-) -> None:
-    ensure_session_dir()
-    path = session_path(session_id)
-    lines = []
-    for message in history:
-        lines.append(
-            json.dumps(
-                {
-                    "role": message["role"],
-                    "content": serialize_content(message["content"]),
-                }
-            )
-        )
-    lines.append(
-        json.dumps(
-            {
-                "input_tokens": last_usage.input_tokens,
-                "cache_creation_input_tokens": last_usage.cache_creation_input_tokens,
-                "cache_read_input_tokens": last_usage.cache_read_input_tokens,
-                "output_tokens": last_usage.output_tokens,
-            }
-        )
-    )
-    path.write_text("\n".join(lines) + "\n")
-
-
-def load_session_history(
-    session_id: str,
-) -> tuple[list[MessageParam], Usage]:
-    path = session_path(session_id)
-    lines = [line for line in path.read_text().splitlines() if line.strip()]
-    *message_lines, usage_line = lines
-    record = json.loads(usage_line)
-    last_usage = Usage(
-        input_tokens=record.get("input_tokens", 0),
-        cache_creation_input_tokens=record.get("cache_creation_input_tokens", 0),
-        cache_read_input_tokens=record.get("cache_read_input_tokens", 0),
-        output_tokens=record.get("output_tokens", 0),
-    )
-    history: list[MessageParam] = [
-        {"role": r["role"], "content": r["content"]}
-        for r in (json.loads(line) for line in message_lines)
-    ]
-    return history, last_usage
-
-
-def summarize_content(content: str | Iterable[object]) -> str:
-    summary = extract_text_content(content)
-    return " ".join(summary.splitlines()).strip()
-
-
 def session_title(history: list[MessageParam]) -> str:
+    """Derive a display title from the first user message."""
     for message in history:
         if message["role"] == "user":
-            title = summarize_content(message["content"])
+            text = extract_text_content(message["content"])
+            title = " ".join(text.splitlines()).strip()
             if title:
                 return title[:60]
     return "Untitled session"
 
 
-def list_sessions() -> list[StoredSession]:
-    ensure_session_dir()
-    sessions: list[StoredSession] = []
-    for path in SESSION_DIR.glob("*.jsonl"):
-        try:
-            history, last_usage = load_session_history(path.stem)
-        except OSError, json.JSONDecodeError, ValueError, KeyError:
-            continue
-        updated_at = datetime.fromtimestamp(path.stat().st_mtime, UTC).isoformat()
-        sessions.append(
-            StoredSession(
-                session_id=path.stem,
-                title=session_title(history),
-                updated_at=updated_at,
-                history=history,
-                last_usage=last_usage,
+class SessionManager:
+    """Manages session files in the --<cwd>--/<timestamp>_<uuidv7>.jsonl format."""
+
+    VERSION = 2
+
+    def __init__(self, session_dir: Path | None = None) -> None:
+        """Initialize with an optional base directory (defaults to SESSION_DIR)."""
+        self._base_dir = session_dir or SESSION_DIR
+
+    @staticmethod
+    def new_id() -> str:
+        """Generate a new UUIDv7 session identifier."""
+        return str(uuid.uuid7())
+
+    @staticmethod
+    def entry_id() -> str:
+        """Generate an 8-char hex entry ID."""
+        return uuid.uuid4().hex[:8]
+
+    def cwd_dir(self, cwd: str | None = None) -> Path:
+        """Return the encoded-cwd subdirectory for the given working directory."""
+        cwd = cwd or str(Path.cwd())
+        resolved = str(Path(cwd).resolve())
+        safe = resolved.lstrip("/").replace("/", "-").replace(":", "-")
+        return self._base_dir / f"--{safe}--"
+
+    def find_file(self, session_id: str) -> Path | None:
+        """Find a session file by its ID across all cwd subdirectories."""
+        if not self._base_dir.exists():
+            return None
+        for cwd_dir in self._base_dir.iterdir():
+            if not cwd_dir.is_dir():
+                continue
+            for f in cwd_dir.glob(f"*_{session_id}.jsonl"):
+                return f
+        return None
+
+    def exists(self, session_id: str) -> bool:
+        """Return True if a session file with the given ID exists."""
+        return self.find_file(session_id) is not None
+
+    def save(
+        self,
+        session_id: str,
+        history: list[MessageParam],
+        usage: Usage,
+        cwd: str | None = None,
+    ) -> None:
+        """Save or append to a session file, preserving existing entry IDs/timestamps."""
+        cwd = cwd or str(Path.cwd())
+        session_dir = self.cwd_dir(cwd)
+        session_dir.mkdir(parents=True, exist_ok=True)
+
+        existing = self.find_file(session_id)
+        if existing:
+            lines = [line for line in existing.read_text().splitlines() if line.strip()]
+            saved = len(lines) - 2  # header + old usage
+            lines = lines[:-1]  # drop old usage, will append new one
+        else:
+            lines = []
+            saved = 0
+
+        for message in history[saved:]:
+            now = datetime.now(UTC)
+            entry_ts = now.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+            lines.append(
+                json.dumps(
+                    {
+                        "type": "message",
+                        "id": self.entry_id(),
+                        "timestamp": entry_ts,
+                        "message": {
+                            "role": message["role"],
+                            "content": serialize_content(message["content"]),
+                            "timestamp": int(now.timestamp() * 1000),
+                        },
+                    }
+                )
+            )
+
+        # Replace usage line (append if new session, overwrite if existing)
+        lines.append(
+            json.dumps(
+                {
+                    "input_tokens": usage.input_tokens,
+                    "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+                    "cache_read_input_tokens": usage.cache_read_input_tokens,
+                    "output_tokens": usage.output_tokens,
+                }
             )
         )
-    return sorted(sessions, key=lambda item: item.updated_at, reverse=True)
+
+        if existing:
+            path = existing
+        else:
+            now = datetime.now(UTC)
+            ts = now.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+            header = {
+                "type": "session",
+                "version": self.VERSION,
+                "id": session_id,
+                "timestamp": ts,
+                "cwd": cwd,
+            }
+            file_timestamp = ts.replace(":", "-").replace(".", "-")
+            path = session_dir / f"{file_timestamp}_{session_id}.jsonl"
+            lines.insert(0, json.dumps(header))
+
+        path.write_text("\n".join(lines) + "\n")
+
+    def load(self, session_id: str) -> tuple[list[MessageParam], Usage]:
+        """Load a session file and return (history, usage)."""
+        path = self.find_file(session_id)
+        if path is None:
+            return [], Usage(0, 0, 0, 0)
+
+        lines = [line for line in path.read_text().splitlines() if line.strip()]
+        *entry_lines, usage_line = lines[1:]
+        record = json.loads(usage_line)
+        usage = Usage(
+            input_tokens=record.get("input_tokens", 0),
+            cache_creation_input_tokens=record.get("cache_creation_input_tokens", 0),
+            cache_read_input_tokens=record.get("cache_read_input_tokens", 0),
+            output_tokens=record.get("output_tokens", 0),
+        )
+        history: list[MessageParam] = []
+        for line in entry_lines:
+            entry = json.loads(line)
+            msg = entry["message"]
+            history.append({"role": msg["role"], "content": msg["content"]})
+        return history, usage
+
+    def list_sessions(self) -> list[StoredSession]:
+        """Return all stored sessions sorted by most recently modified."""
+        if not self._base_dir.exists():
+            return []
+        sessions: list[StoredSession] = []
+        for cwd_dir in self._base_dir.iterdir():
+            if not cwd_dir.is_dir():
+                continue
+            for path in cwd_dir.glob("*.jsonl"):
+                try:
+                    content = path.read_text()
+                    lines = [line for line in content.splitlines() if line.strip()]
+                    if not lines:
+                        continue
+                    header = json.loads(lines[0])
+                    if header.get("type") != "session":
+                        continue
+                    sid = header.get("id", "")
+                    if not sid:
+                        continue
+                    *entry_lines, usage_line = lines[1:]
+                    record = json.loads(usage_line)
+                    usage = Usage(
+                        input_tokens=record.get("input_tokens", 0),
+                        cache_creation_input_tokens=record.get(
+                            "cache_creation_input_tokens", 0
+                        ),
+                        cache_read_input_tokens=record.get(
+                            "cache_read_input_tokens", 0
+                        ),
+                        output_tokens=record.get("output_tokens", 0),
+                    )
+                    max_ts = 0
+                    history: list[MessageParam] = []
+                    for line in entry_lines:
+                        entry = json.loads(line)
+                        msg = entry["message"]
+                        history.append({"role": msg["role"], "content": msg["content"]})
+                        ts = msg.get("timestamp", 0)
+                        if ts > max_ts:
+                            max_ts = ts
+                    updated_at = (
+                        datetime.fromtimestamp(max_ts / 1000, UTC).isoformat()
+                        if max_ts
+                        else header.get("timestamp", "")
+                    )
+                    sessions.append(
+                        StoredSession(
+                            session_id=sid,
+                            title=session_title(history),
+                            updated_at=updated_at,
+                            history=history,
+                            last_usage=usage,
+                        )
+                    )
+                except OSError, json.JSONDecodeError, ValueError, KeyError:
+                    continue
+        return sorted(sessions, key=lambda item: item.updated_at, reverse=True)
 
 
 def format_relative_time(timestamp: str) -> str:
+    """Format an ISO timestamp as a human-readable relative time string."""
     updated_at = datetime.fromisoformat(timestamp)
     now = datetime.now(UTC)
     delta = now - updated_at.astimezone(UTC)
@@ -157,12 +266,14 @@ def format_relative_time(timestamp: str) -> str:
 
 
 def format_session_choice(stored: StoredSession) -> str:
+    """Format a StoredSession for display in the session picker."""
     return f"{stored.title} ({format_relative_time(stored.updated_at)})"
 
 
 def select_session(
     sessions: list[StoredSession], current_session_id: str | None = None
 ) -> str | None:
+    """Show an interactive picker and return the selected session ID, or None."""
     selected_index = 0
     if current_session_id is not None:
         for i, session in enumerate(sessions):
@@ -179,11 +290,13 @@ def select_session(
 
 
 def prompt_resume(
+    manager: SessionManager,
     current_session_id: str,
     history: list[MessageParam],
 ) -> tuple[str, list[MessageParam], bool]:
+    """Show the session picker and return (session_id, history, resumed)."""
     clear_terminal()
-    sessions = list_sessions()
+    sessions = manager.list_sessions()
     if not sessions:
         print("No saved sessions found.\n")
         return current_session_id, history, False

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -49,7 +49,7 @@ def session_title(history: list[MessageParam]) -> str:
 
 
 class SessionManager:
-    VERSION = 2
+    VERSION = 1
 
     def __init__(self, session_dir: Path | None = None) -> None:
         self._base_dir = session_dir or SESSION_DIR

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -65,8 +65,10 @@ class SessionManager:
     def cwd_dir(self, cwd: str | None = None) -> Path:
         cwd = cwd or str(Path.cwd())
         resolved = str(Path(cwd).resolve())
-        safe = resolved.lstrip("/").replace("/", "-").replace(":", "-")
-        return self._base_dir / f"--{safe}--"
+        safe = (
+            resolved.lstrip("/").replace("/", "-").replace(":", "-").replace(".", "-")
+        )
+        return self._base_dir / safe
 
     def find_file(self, session_id: str) -> Path | None:
         if not self._base_dir.exists():

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -53,7 +53,6 @@ class SessionManager:
 
     def __init__(self, session_dir: Path | None = None) -> None:
         self._base_dir = session_dir or SESSION_DIR
-        self._leaf_overrides: dict[str, str | None] = {}
 
     @staticmethod
     def new_id() -> str:
@@ -81,42 +80,6 @@ class SessionManager:
 
     def exists(self, session_id: str) -> bool:
         return self.find_file(session_id) is not None
-
-    def get_leaf_id(self, session_id: str) -> str | None:
-        path = self.find_file(session_id)
-        if path is None:
-            return None
-        lines = [line for line in path.read_text().splitlines() if line.strip()]
-        if len(lines) <= 1:
-            return None
-        try:
-            last_entry = json.loads(lines[-1])
-        except json.JSONDecodeError:
-            return None
-        return last_entry.get("id")
-
-    def branch(self, session_id: str, branch_from_id: str | None) -> None:
-        if branch_from_id is not None:
-            path = self.find_file(session_id)
-            if path is None:
-                raise ValueError(f"Session {session_id} not found")
-            lines = [line for line in path.read_text().splitlines() if line.strip()]
-            found = any(
-                json.loads(line).get("id") == branch_from_id for line in lines[1:]
-            )
-            if not found:
-                raise ValueError(
-                    f"Entry {branch_from_id} not found in session {session_id}"
-                )
-        self._leaf_overrides[session_id] = branch_from_id
-
-    def determine_parent(self, session_id: str, entries: list[dict]) -> str | None:
-        if session_id in self._leaf_overrides:
-            parent = self._leaf_overrides.pop(session_id)
-            return parent
-        if entries:
-            return entries[-1]["id"]
-        return None
 
     def save(
         self,
@@ -150,8 +113,7 @@ class SessionManager:
                 ):
                     saved_asst += 1
 
-        non_header = entries[1:] if entries else []
-        parent_id = self.determine_parent(session_id, non_header)
+        parent_id = entries[-1]["id"] if len(entries) > 1 else None
 
         for message in history[existing_entry_count:]:
             now = datetime.now(UTC)

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -89,7 +89,10 @@ class SessionManager:
         lines = [line for line in path.read_text().splitlines() if line.strip()]
         if len(lines) <= 1:
             return None
-        last_entry = json.loads(lines[-1])
+        try:
+            last_entry = json.loads(lines[-1])
+        except json.JSONDecodeError:
+            return None
         return last_entry.get("id")
 
     def branch(self, session_id: str, branch_from_id: str | None) -> None:
@@ -129,7 +132,10 @@ class SessionManager:
         existing = self.find_file(session_id)
         if existing:
             lines = [line for line in existing.read_text().splitlines() if line.strip()]
-            entries = [json.loads(line) for line in lines]
+            try:
+                entries = [json.loads(line) for line in lines]
+            except json.JSONDecodeError:
+                entries = []
         else:
             entries = []
 
@@ -206,7 +212,10 @@ class SessionManager:
         history: list[MessageParam] = []
         round_usages: list[Usage] = []
         for line in lines[1:]:
-            entry = json.loads(line)
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
             msg = entry["message"]
             history.append({"role": msg["role"], "content": msg["content"]})
             if msg["role"] == "assistant":

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -21,11 +21,10 @@ class StoredSession:
     title: str
     updated_at: str
     history: list[MessageParam]
-    last_usage: Usage
+    round_usages: list[Usage]
 
 
 def serialize_content(content: str | Iterable[object]) -> str | list[object]:
-    """Serialize message content blocks for JSON output."""
     if isinstance(content, str):
         return content
     serialized_blocks: list[object] = []
@@ -40,7 +39,6 @@ def serialize_content(content: str | Iterable[object]) -> str | list[object]:
 
 
 def session_title(history: list[MessageParam]) -> str:
-    """Derive a display title from the first user message."""
     for message in history:
         if message["role"] == "user":
             text = extract_text_content(message["content"])
@@ -51,33 +49,26 @@ def session_title(history: list[MessageParam]) -> str:
 
 
 class SessionManager:
-    """Manages session files in the --<cwd>--/<timestamp>_<uuidv7>.jsonl format."""
-
     VERSION = 2
 
     def __init__(self, session_dir: Path | None = None) -> None:
-        """Initialize with an optional base directory (defaults to SESSION_DIR)."""
         self._base_dir = session_dir or SESSION_DIR
 
     @staticmethod
     def new_id() -> str:
-        """Generate a new UUIDv7 session identifier."""
         return str(uuid.uuid7())
 
     @staticmethod
     def entry_id() -> str:
-        """Generate an 8-char hex entry ID."""
         return uuid.uuid4().hex[:8]
 
     def cwd_dir(self, cwd: str | None = None) -> Path:
-        """Return the encoded-cwd subdirectory for the given working directory."""
         cwd = cwd or str(Path.cwd())
         resolved = str(Path(cwd).resolve())
         safe = resolved.lstrip("/").replace("/", "-").replace(":", "-")
         return self._base_dir / f"--{safe}--"
 
     def find_file(self, session_id: str) -> Path | None:
-        """Find a session file by its ID across all cwd subdirectories."""
         if not self._base_dir.exists():
             return None
         for cwd_dir in self._base_dir.iterdir():
@@ -88,17 +79,15 @@ class SessionManager:
         return None
 
     def exists(self, session_id: str) -> bool:
-        """Return True if a session file with the given ID exists."""
         return self.find_file(session_id) is not None
 
     def save(
         self,
         session_id: str,
         history: list[MessageParam],
-        usage: Usage,
+        round_usages: list[Usage] | None = None,
         cwd: str | None = None,
     ) -> None:
-        """Save or append to a session file, preserving existing entry IDs/timestamps."""
         cwd = cwd or str(Path.cwd())
         session_dir = self.cwd_dir(cwd)
         session_dir.mkdir(parents=True, exist_ok=True)
@@ -106,41 +95,57 @@ class SessionManager:
         existing = self.find_file(session_id)
         if existing:
             lines = [line for line in existing.read_text().splitlines() if line.strip()]
-            saved = len(lines) - 2  # header + old usage
-            lines = lines[:-1]  # drop old usage, will append new one
         else:
             lines = []
-            saved = 0
 
-        for message in history[saved:]:
+        saved_asst = 0
+        if existing:
+            for line in lines[1:]:
+                entry = json.loads(line)
+                if (
+                    entry.get("type") == "message"
+                    and entry["message"]["role"] == "assistant"
+                ):
+                    saved_asst += 1
+
+        for message in history[len(lines) - (1 if existing else 0) :]:
             now = datetime.now(UTC)
             entry_ts = now.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+            msg_body: dict = {
+                "role": message["role"],
+                "content": serialize_content(message["content"]),
+                "timestamp": int(now.timestamp() * 1000),
+            }
+            if (
+                message["role"] == "assistant"
+                and round_usages
+                and saved_asst < len(round_usages)
+            ):
+                u = round_usages[saved_asst]
+                total = (
+                    u.input_tokens
+                    + u.cache_creation_input_tokens
+                    + u.cache_read_input_tokens
+                    + u.output_tokens
+                )
+                msg_body["usage"] = {
+                    "input": u.input_tokens,
+                    "output": u.output_tokens,
+                    "cacheRead": u.cache_read_input_tokens,
+                    "cacheWrite": u.cache_creation_input_tokens,
+                    "totalTokens": total,
+                }
+                saved_asst += 1
             lines.append(
                 json.dumps(
                     {
                         "type": "message",
                         "id": self.entry_id(),
                         "timestamp": entry_ts,
-                        "message": {
-                            "role": message["role"],
-                            "content": serialize_content(message["content"]),
-                            "timestamp": int(now.timestamp() * 1000),
-                        },
+                        "message": msg_body,
                     }
                 )
             )
-
-        # Replace usage line (append if new session, overwrite if existing)
-        lines.append(
-            json.dumps(
-                {
-                    "input_tokens": usage.input_tokens,
-                    "cache_creation_input_tokens": usage.cache_creation_input_tokens,
-                    "cache_read_input_tokens": usage.cache_read_input_tokens,
-                    "output_tokens": usage.output_tokens,
-                }
-            )
-        )
 
         if existing:
             path = existing
@@ -160,30 +165,32 @@ class SessionManager:
 
         path.write_text("\n".join(lines) + "\n")
 
-    def load(self, session_id: str) -> tuple[list[MessageParam], Usage]:
-        """Load a session file and return (history, usage)."""
+    def load(self, session_id: str) -> tuple[list[MessageParam], list[Usage]]:
         path = self.find_file(session_id)
         if path is None:
-            return [], Usage(0, 0, 0, 0)
+            return [], []
 
         lines = [line for line in path.read_text().splitlines() if line.strip()]
-        *entry_lines, usage_line = lines[1:]
-        record = json.loads(usage_line)
-        usage = Usage(
-            input_tokens=record.get("input_tokens", 0),
-            cache_creation_input_tokens=record.get("cache_creation_input_tokens", 0),
-            cache_read_input_tokens=record.get("cache_read_input_tokens", 0),
-            output_tokens=record.get("output_tokens", 0),
-        )
         history: list[MessageParam] = []
-        for line in entry_lines:
+        round_usages: list[Usage] = []
+        for line in lines[1:]:
             entry = json.loads(line)
             msg = entry["message"]
             history.append({"role": msg["role"], "content": msg["content"]})
-        return history, usage
+            if msg["role"] == "assistant":
+                u = msg.get("usage")
+                if u:
+                    round_usages.append(
+                        Usage(
+                            input_tokens=u.get("input", 0),
+                            cache_creation_input_tokens=u.get("cacheWrite", 0),
+                            cache_read_input_tokens=u.get("cacheRead", 0),
+                            output_tokens=u.get("output", 0),
+                        )
+                    )
+        return history, round_usages
 
     def list_sessions(self) -> list[StoredSession]:
-        """Return all stored sessions sorted by most recently modified."""
         if not self._base_dir.exists():
             return []
         sessions: list[StoredSession] = []
@@ -202,20 +209,10 @@ class SessionManager:
                     sid = header.get("id", "")
                     if not sid:
                         continue
-                    *entry_lines, usage_line = lines[1:]
-                    record = json.loads(usage_line)
-                    usage = Usage(
-                        input_tokens=record.get("input_tokens", 0),
-                        cache_creation_input_tokens=record.get(
-                            "cache_creation_input_tokens", 0
-                        ),
-                        cache_read_input_tokens=record.get(
-                            "cache_read_input_tokens", 0
-                        ),
-                        output_tokens=record.get("output_tokens", 0),
-                    )
+                    entry_lines = lines[1:]
                     max_ts = 0
                     history: list[MessageParam] = []
+                    round_usages: list[Usage] = []
                     for line in entry_lines:
                         entry = json.loads(line)
                         msg = entry["message"]
@@ -223,6 +220,19 @@ class SessionManager:
                         ts = msg.get("timestamp", 0)
                         if ts > max_ts:
                             max_ts = ts
+                        if msg["role"] == "assistant":
+                            u = msg.get("usage")
+                            if u:
+                                round_usages.append(
+                                    Usage(
+                                        input_tokens=u.get("input", 0),
+                                        cache_creation_input_tokens=u.get(
+                                            "cacheWrite", 0
+                                        ),
+                                        cache_read_input_tokens=u.get("cacheRead", 0),
+                                        output_tokens=u.get("output", 0),
+                                    )
+                                )
                     updated_at = (
                         datetime.fromtimestamp(max_ts / 1000, UTC).isoformat()
                         if max_ts
@@ -234,7 +244,7 @@ class SessionManager:
                             title=session_title(history),
                             updated_at=updated_at,
                             history=history,
-                            last_usage=usage,
+                            round_usages=round_usages,
                         )
                     )
                 except OSError, json.JSONDecodeError, ValueError, KeyError:
@@ -243,7 +253,6 @@ class SessionManager:
 
 
 def format_relative_time(timestamp: str) -> str:
-    """Format an ISO timestamp as a human-readable relative time string."""
     updated_at = datetime.fromisoformat(timestamp)
     now = datetime.now(UTC)
     delta = now - updated_at.astimezone(UTC)
@@ -266,14 +275,12 @@ def format_relative_time(timestamp: str) -> str:
 
 
 def format_session_choice(stored: StoredSession) -> str:
-    """Format a StoredSession for display in the session picker."""
     return f"{stored.title} ({format_relative_time(stored.updated_at)})"
 
 
 def select_session(
     sessions: list[StoredSession], current_session_id: str | None = None
 ) -> str | None:
-    """Show an interactive picker and return the selected session ID, or None."""
     selected_index = 0
     if current_session_id is not None:
         for i, session in enumerate(sessions):
@@ -294,7 +301,6 @@ def prompt_resume(
     current_session_id: str,
     history: list[MessageParam],
 ) -> tuple[str, list[MessageParam], bool]:
-    """Show the session picker and return (session_id, history, resumed)."""
     clear_terminal()
     sessions = manager.list_sessions()
     if not sessions:
@@ -310,5 +316,5 @@ def prompt_resume(
 
     chosen = next(stored for stored in sessions if stored.session_id == result)
     print_session_history(chosen.history)
-    token_tracker.restore(chosen.last_usage)
+    token_tracker.restore(chosen.round_usages)
     return chosen.session_id, chosen.history.copy(), True

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -53,6 +53,7 @@ class SessionManager:
 
     def __init__(self, session_dir: Path | None = None) -> None:
         self._base_dir = session_dir or SESSION_DIR
+        self._leaf_overrides: dict[str, str | None] = {}
 
     @staticmethod
     def new_id() -> str:
@@ -81,6 +82,39 @@ class SessionManager:
     def exists(self, session_id: str) -> bool:
         return self.find_file(session_id) is not None
 
+    def get_leaf_id(self, session_id: str) -> str | None:
+        path = self.find_file(session_id)
+        if path is None:
+            return None
+        lines = [line for line in path.read_text().splitlines() if line.strip()]
+        if len(lines) <= 1:
+            return None
+        last_entry = json.loads(lines[-1])
+        return last_entry.get("id")
+
+    def branch(self, session_id: str, branch_from_id: str | None) -> None:
+        if branch_from_id is not None:
+            path = self.find_file(session_id)
+            if path is None:
+                raise ValueError(f"Session {session_id} not found")
+            lines = [line for line in path.read_text().splitlines() if line.strip()]
+            found = any(
+                json.loads(line).get("id") == branch_from_id for line in lines[1:]
+            )
+            if not found:
+                raise ValueError(
+                    f"Entry {branch_from_id} not found in session {session_id}"
+                )
+        self._leaf_overrides[session_id] = branch_from_id
+
+    def determine_parent(self, session_id: str, entries: list[dict]) -> str | None:
+        if session_id in self._leaf_overrides:
+            parent = self._leaf_overrides.pop(session_id)
+            return parent
+        if entries:
+            return entries[-1]["id"]
+        return None
+
     def save(
         self,
         session_id: str,
@@ -95,22 +129,28 @@ class SessionManager:
         existing = self.find_file(session_id)
         if existing:
             lines = [line for line in existing.read_text().splitlines() if line.strip()]
+            entries = [json.loads(line) for line in lines]
         else:
-            lines = []
+            entries = []
+
+        existing_entry_count = max(len(entries) - 1, 0) if entries else 0
 
         saved_asst = 0
         if existing:
-            for line in lines[1:]:
-                entry = json.loads(line)
+            for entry in entries[1:]:
                 if (
                     entry.get("type") == "message"
                     and entry["message"]["role"] == "assistant"
                 ):
                     saved_asst += 1
 
-        for message in history[len(lines) - (1 if existing else 0) :]:
+        non_header = entries[1:] if entries else []
+        parent_id = self.determine_parent(session_id, non_header)
+
+        for message in history[existing_entry_count:]:
             now = datetime.now(UTC)
             entry_ts = now.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+            new_id = self.entry_id()
             msg_body: dict = {
                 "role": message["role"],
                 "content": serialize_content(message["content"]),
@@ -128,16 +168,16 @@ class SessionManager:
                         "output_tokens": u.output_tokens,
                     }
                     saved_asst += 1
-            lines.append(
-                json.dumps(
-                    {
-                        "type": "message",
-                        "id": self.entry_id(),
-                        "timestamp": entry_ts,
-                        "message": msg_body,
-                    }
-                )
+            entries.append(
+                {
+                    "type": "message",
+                    "id": new_id,
+                    "parent_id": parent_id,
+                    "timestamp": entry_ts,
+                    "message": msg_body,
+                }
             )
+            parent_id = new_id
 
         if existing:
             path = existing
@@ -153,9 +193,9 @@ class SessionManager:
             }
             file_timestamp = ts.replace(":", "-").replace(".", "-")
             path = session_dir / f"{file_timestamp}_{session_id}.jsonl"
-            lines.insert(0, json.dumps(header))
+            entries.insert(0, header)
 
-        path.write_text("\n".join(lines) + "\n")
+        path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
 
     def load(self, session_id: str) -> tuple[list[MessageParam], list[Usage]]:
         path = self.find_file(session_id)

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -65,10 +65,8 @@ class SessionManager:
     def cwd_dir(self, cwd: str | None = None) -> Path:
         cwd = cwd or str(Path.cwd())
         resolved = str(Path(cwd).resolve())
-        safe = (
-            resolved.lstrip("/").replace("/", "-").replace(":", "-").replace(".", "-")
-        )
-        return self._base_dir / safe
+        safe = resolved.lstrip("/").replace("/", "-").replace(":", "-")
+        return self._base_dir / (safe or "__root__")
 
     def find_file(self, session_id: str) -> Path | None:
         if not self._base_dir.exists():

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -97,8 +97,8 @@ class SessionManager:
             lines = [line for line in existing.read_text().splitlines() if line.strip()]
             try:
                 entries = [json.loads(line) for line in lines]
-            except json.JSONDecodeError:
-                entries = []
+            except json.JSONDecodeError as err:
+                raise ValueError(f"Invalid JSON in session file: {existing}") from err
         else:
             entries = []
 

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -121,18 +121,11 @@ class SessionManager:
                 msg_body["model"] = config.get_model()
                 if round_usages and saved_asst < len(round_usages):
                     u = round_usages[saved_asst]
-                    total = (
-                        u.input_tokens
-                        + u.cache_creation_input_tokens
-                        + u.cache_read_input_tokens
-                        + u.output_tokens
-                    )
                     msg_body["usage"] = {
-                        "input": u.input_tokens,
-                        "output": u.output_tokens,
-                        "cacheRead": u.cache_read_input_tokens,
-                        "cacheWrite": u.cache_creation_input_tokens,
-                        "totalTokens": total,
+                        "input_tokens": u.input_tokens,
+                        "cache_creation_input_tokens": u.cache_creation_input_tokens,
+                        "cache_read_input_tokens": u.cache_read_input_tokens,
+                        "output_tokens": u.output_tokens,
                     }
                     saved_asst += 1
             lines.append(
@@ -181,10 +174,12 @@ class SessionManager:
                 if u:
                     round_usages.append(
                         Usage(
-                            input_tokens=u.get("input", 0),
-                            cache_creation_input_tokens=u.get("cacheWrite", 0),
-                            cache_read_input_tokens=u.get("cacheRead", 0),
-                            output_tokens=u.get("output", 0),
+                            input_tokens=u.get("input_tokens", 0),
+                            cache_creation_input_tokens=u.get(
+                                "cache_creation_input_tokens", 0
+                            ),
+                            cache_read_input_tokens=u.get("cache_read_input_tokens", 0),
+                            output_tokens=u.get("output_tokens", 0),
                         )
                     )
         return history, round_usages
@@ -224,12 +219,14 @@ class SessionManager:
                             if u:
                                 round_usages.append(
                                     Usage(
-                                        input_tokens=u.get("input", 0),
+                                        input_tokens=u.get("input_tokens", 0),
                                         cache_creation_input_tokens=u.get(
-                                            "cacheWrite", 0
+                                            "cache_creation_input_tokens", 0
                                         ),
-                                        cache_read_input_tokens=u.get("cacheRead", 0),
-                                        output_tokens=u.get("output", 0),
+                                        cache_read_input_tokens=u.get(
+                                            "cache_read_input_tokens", 0
+                                        ),
+                                        output_tokens=u.get("output_tokens", 0),
                                     )
                                 )
                     updated_at = (

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -74,8 +74,9 @@ class SessionManager:
         for cwd_dir in self._base_dir.iterdir():
             if not cwd_dir.is_dir():
                 continue
-            for f in cwd_dir.glob(f"*_{session_id}.jsonl"):
-                return f
+            candidate = cwd_dir / f"{session_id}.jsonl"
+            if candidate.exists():
+                return candidate
         return None
 
     def exists(self, session_id: str) -> bool:
@@ -159,8 +160,7 @@ class SessionManager:
                 "timestamp": ts,
                 "cwd": cwd,
             }
-            file_timestamp = ts.replace(":", "-").replace(".", "-")
-            path = session_dir / f"{file_timestamp}_{session_id}.jsonl"
+            path = session_dir / f"{session_id}.jsonl"
             entries.insert(0, header)
 
         path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -76,9 +76,8 @@ class SessionManager:
         for cwd_dir in self._base_dir.iterdir():
             if not cwd_dir.is_dir():
                 continue
-            candidate = cwd_dir / f"{session_id}.jsonl"
-            if candidate.exists():
-                return candidate
+            for f in cwd_dir.glob(f"*_{session_id}.jsonl"):
+                return f
         return None
 
     def exists(self, session_id: str) -> bool:
@@ -162,7 +161,8 @@ class SessionManager:
                 "timestamp": ts,
                 "cwd": cwd,
             }
-            path = session_dir / f"{session_id}.jsonl"
+            file_timestamp = ts.replace(":", "-").replace(".", "-")
+            path = session_dir / f"{file_timestamp}_{session_id}.jsonl"
             entries.insert(0, header)
 
         path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")

--- a/src/mini_agent/cli/sessions.py
+++ b/src/mini_agent/cli/sessions.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from anthropic.types import MessageParam
 from pydantic import BaseModel
 
-from ..config import SESSION_DIR
+from ..config import SESSION_DIR, config
 from .clipboard import extract_text_content
 from .display import clear_terminal, print_session_history
 from .display.picker import select_from_list
@@ -116,26 +116,25 @@ class SessionManager:
                 "content": serialize_content(message["content"]),
                 "timestamp": int(now.timestamp() * 1000),
             }
-            if (
-                message["role"] == "assistant"
-                and round_usages
-                and saved_asst < len(round_usages)
-            ):
-                u = round_usages[saved_asst]
-                total = (
-                    u.input_tokens
-                    + u.cache_creation_input_tokens
-                    + u.cache_read_input_tokens
-                    + u.output_tokens
-                )
-                msg_body["usage"] = {
-                    "input": u.input_tokens,
-                    "output": u.output_tokens,
-                    "cacheRead": u.cache_read_input_tokens,
-                    "cacheWrite": u.cache_creation_input_tokens,
-                    "totalTokens": total,
-                }
-                saved_asst += 1
+            if message["role"] == "assistant":
+                msg_body["api"] = "anthropic-messages"
+                msg_body["model"] = config.get_model()
+                if round_usages and saved_asst < len(round_usages):
+                    u = round_usages[saved_asst]
+                    total = (
+                        u.input_tokens
+                        + u.cache_creation_input_tokens
+                        + u.cache_read_input_tokens
+                        + u.output_tokens
+                    )
+                    msg_body["usage"] = {
+                        "input": u.input_tokens,
+                        "output": u.output_tokens,
+                        "cacheRead": u.cache_read_input_tokens,
+                        "cacheWrite": u.cache_creation_input_tokens,
+                        "totalTokens": total,
+                    }
+                    saved_asst += 1
             lines.append(
                 json.dumps(
                     {

--- a/src/mini_agent/cli/token.py
+++ b/src/mini_agent/cli/token.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class Usage:
+    """Token counts for one assistant response round."""
+
     input_tokens: int
     cache_creation_input_tokens: int
     cache_read_input_tokens: int
@@ -10,6 +12,7 @@ class Usage:
 
     @property
     def total_input_tokens(self) -> int:
+        """Sum of all input-side token counts."""
         return (
             self.input_tokens
             + self.cache_creation_input_tokens
@@ -18,30 +21,35 @@ class Usage:
 
 
 class TokenTracker:
+    """Tracks per-round token usage and computes accumulated totals."""
+
     def __init__(self) -> None:
-        self._rounds: list[Usage] = []
-        self._total_usage: Usage | None = None
-        self._last_round: Usage | None = None
+        """Initialize with empty usage history."""
+        self.round_usages: list[Usage] = []
+        self.total_usage: Usage | None = None
+        self.last_round: Usage | None = None
 
     def update(self, usage: Usage) -> None:
-        self._rounds.append(usage)
-        self._last_round = usage
-        if self._total_usage is None:
-            self._total_usage = usage
+        """Record a new round's usage and update accumulated total."""
+        self.round_usages.append(usage)
+        self.last_round = usage
+        if self.total_usage is None:
+            self.total_usage = usage
         else:
-            self._total_usage = Usage(
-                input_tokens=self._total_usage.input_tokens + usage.input_tokens,
-                cache_creation_input_tokens=self._total_usage.cache_creation_input_tokens
+            self.total_usage = Usage(
+                input_tokens=self.total_usage.input_tokens + usage.input_tokens,
+                cache_creation_input_tokens=self.total_usage.cache_creation_input_tokens
                 + usage.cache_creation_input_tokens,
-                cache_read_input_tokens=self._total_usage.cache_read_input_tokens
+                cache_read_input_tokens=self.total_usage.cache_read_input_tokens
                 + usage.cache_read_input_tokens,
-                output_tokens=self._total_usage.output_tokens + usage.output_tokens,
+                output_tokens=self.total_usage.output_tokens + usage.output_tokens,
             )
 
-    def restore(self, rounds: list[Usage]) -> None:
-        self._rounds = list(rounds)
+    def restore(self, round_usages: list[Usage]) -> None:
+        """Restore state from a list of per-round usages, computing the total."""
+        self.round_usages = list(round_usages)
         total: Usage | None = None
-        for u in rounds:
+        for u in round_usages:
             total = (
                 u
                 if total is None
@@ -54,23 +62,22 @@ class TokenTracker:
                     output_tokens=total.output_tokens + u.output_tokens,
                 )
             )
-        self._total_usage = total
-        self._last_round = rounds[-1] if rounds else None
+        self.total_usage = total
+        self.last_round = round_usages[-1] if round_usages else None
 
     def reset(self) -> None:
-        self._rounds.clear()
-        self._total_usage = None
-        self._last_round = None
-
-    @property
-    def rounds(self) -> list[Usage]:
-        return list(self._rounds)
+        """Clear all tracked usage data."""
+        self.round_usages.clear()
+        self.total_usage = None
+        self.last_round = None
 
     def get(self) -> Usage | None:
-        return self._total_usage
+        """Return the accumulated total usage, or None if no rounds recorded."""
+        return self.total_usage
 
     def get_last_round(self) -> Usage | None:
-        return self._last_round
+        """Return the most recent round's usage, or None if no rounds recorded."""
+        return self.last_round
 
 
 token_tracker = TokenTracker()

--- a/src/mini_agent/cli/token.py
+++ b/src/mini_agent/cli/token.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class Usage:
-    input_tokens: int  # tokens after the last cache breakpoint
-    cache_creation_input_tokens: int  # tokens written to cache
-    cache_read_input_tokens: int  # tokens read from cache
+    input_tokens: int
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
     output_tokens: int
 
     @property
@@ -19,10 +19,12 @@ class Usage:
 
 class TokenTracker:
     def __init__(self) -> None:
+        self._rounds: list[Usage] = []
         self._total_usage: Usage | None = None
         self._last_round: Usage | None = None
 
     def update(self, usage: Usage) -> None:
+        self._rounds.append(usage)
         self._last_round = usage
         if self._total_usage is None:
             self._total_usage = usage
@@ -36,13 +38,33 @@ class TokenTracker:
                 output_tokens=self._total_usage.output_tokens + usage.output_tokens,
             )
 
-    def restore(self, total_usage: Usage) -> None:
-        self._total_usage = total_usage
-        self._last_round = None
+    def restore(self, rounds: list[Usage]) -> None:
+        self._rounds = list(rounds)
+        total: Usage | None = None
+        for u in rounds:
+            total = (
+                u
+                if total is None
+                else Usage(
+                    input_tokens=total.input_tokens + u.input_tokens,
+                    cache_creation_input_tokens=total.cache_creation_input_tokens
+                    + u.cache_creation_input_tokens,
+                    cache_read_input_tokens=total.cache_read_input_tokens
+                    + u.cache_read_input_tokens,
+                    output_tokens=total.output_tokens + u.output_tokens,
+                )
+            )
+        self._total_usage = total
+        self._last_round = rounds[-1] if rounds else None
 
     def reset(self) -> None:
+        self._rounds.clear()
         self._total_usage = None
         self._last_round = None
+
+    @property
+    def rounds(self) -> list[Usage]:
+        return list(self._rounds)
 
     def get(self) -> Usage | None:
         return self._total_usage

--- a/src/mini_agent/cli/token.py
+++ b/src/mini_agent/cli/token.py
@@ -3,16 +3,23 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class Usage:
-    """Token counts for one assistant response round."""
-
     input_tokens: int
     cache_creation_input_tokens: int
     cache_read_input_tokens: int
     output_tokens: int
 
+    def __add__(self, other: Usage) -> Usage:
+        return Usage(
+            input_tokens=self.input_tokens + other.input_tokens,
+            cache_creation_input_tokens=self.cache_creation_input_tokens
+            + other.cache_creation_input_tokens,
+            cache_read_input_tokens=self.cache_read_input_tokens
+            + other.cache_read_input_tokens,
+            output_tokens=self.output_tokens + other.output_tokens,
+        )
+
     @property
     def total_input_tokens(self) -> int:
-        """Sum of all input-side token counts."""
         return (
             self.input_tokens
             + self.cache_creation_input_tokens
@@ -30,39 +37,19 @@ class TokenTracker:
         self.last_round: Usage | None = None
 
     def update(self, usage: Usage) -> None:
-        """Record a new round's usage and update accumulated total."""
         self.round_usages.append(usage)
         self.last_round = usage
         if self.total_usage is None:
             self.total_usage = usage
         else:
-            self.total_usage = Usage(
-                input_tokens=self.total_usage.input_tokens + usage.input_tokens,
-                cache_creation_input_tokens=self.total_usage.cache_creation_input_tokens
-                + usage.cache_creation_input_tokens,
-                cache_read_input_tokens=self.total_usage.cache_read_input_tokens
-                + usage.cache_read_input_tokens,
-                output_tokens=self.total_usage.output_tokens + usage.output_tokens,
-            )
+            self.total_usage = self.total_usage + usage
 
     def restore(self, round_usages: list[Usage]) -> None:
-        """Restore state from a list of per-round usages, computing the total."""
         self.round_usages = list(round_usages)
-        total: Usage | None = None
-        for u in round_usages:
-            total = (
-                u
-                if total is None
-                else Usage(
-                    input_tokens=total.input_tokens + u.input_tokens,
-                    cache_creation_input_tokens=total.cache_creation_input_tokens
-                    + u.cache_creation_input_tokens,
-                    cache_read_input_tokens=total.cache_read_input_tokens
-                    + u.cache_read_input_tokens,
-                    output_tokens=total.output_tokens + u.output_tokens,
-                )
-            )
-        self.total_usage = total
+        if round_usages:
+            self.total_usage = sum(round_usages[1:], start=round_usages[0])
+        else:
+            self.total_usage = None
         self.last_round = round_usages[-1] if round_usages else None
 
     def reset(self) -> None:


### PR DESCRIPTION
## Description

Bug fixes and refactors for session replay, storage, and token tracking.

Closes #11.

### Session replay fix

`print_session_history` previously only rendered plain text blocks. Tool calls, tool results, thinking content, and bash output were silently skipped during replay. Now replay fully reconstructs the live session:
- **tool_use blocks** rendered via `print_tool_start()` and registered in a `tool_use_id` → `(name, input)` registry
- **tool_result blocks** matched to their tool_use via the registry and rendered via `print_tool_result()`
- **thinking blocks** rendered as Markdown with `dim italic` style
- **bash output** printed line-by-line with ANSI decoding and `dim` styling

### Session storage refactor

- **SessionManager class** replaces free functions (`save_session_history`, `load_session_history`, `list_sessions`, etc.). Provides `new_id()` (UUID7), `save()`, `load()`, `list_sessions()`, `exists()`.
- **JSONL format v1**: header entry with `type`, `version`, `id`, `timestamp`, `cwd`. Each message entry has `id`, `parent_id` (linear chain), `timestamp`, and per-assistant-message `usage`.
- **cwd-based directory layout**: sessions organized into directories keyed by working directory, with timestamped filenames.
- **Usage per assistant message**: `StoredSession.round_usages: list[Usage]` replaces `last_usage`. Token usage embedded per assistant message entry.
- **String content serialization**: plain strings wrapped as `[{"type": "text", "text": "..."}]` for block consistency.
- **JSON decode resilience**: `save()` and `load()` handle corrupt session files gracefully.

### Token tracker refactor

- `Usage.__add__` operator simplifies accumulation in `update()` and `restore()`.
- `restore()` accepts a list of per-round usages and recomputes the total.
- Public attributes renamed (`total_usage`, `last_round`, `round_usages`) with docstrings.

### Thinking style

- New `THINKING_STYLE_RICH = "dim italic"` used for thinking content in both live streaming and session replay.

## Type of change

- [x] Bug fix
- [x] Refactor
- [x] Breaking change (session format v1, `StoredSession` API, `TokenTracker` API)

## Test

All lint, format, and type checks pass.

---

Assisted-by: mini-agent:deepseek-v4-pro
