### PR TITLE
feat(config): support custom provider and implement nested limits fallback

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -6,11 +6,13 @@ Config stored in `~/.mini-agent/config.toml`.
 |---|---|---|
 | `model_id` | `claude-sonnet-4-6` | Any model ID from `/v1/models` |
 | `reasoning_effort` | `high` | `disabled`, `adaptive`, `low`, `medium`, `high`, `xhigh`, `max` |
+| `provider` | *(none)* | Any provider ID from [models.dev](https://models.dev/) |
 
 ## Example
 
 ```toml
-model_id = "claude-sonnet-4-6"
+provider = "openrouter"
+model_id = "gemini-3.5-flash"
 reasoning_effort = "high"
 ```
 
@@ -18,3 +20,11 @@ reasoning_effort = "high"
 
 - `/model` in interactive mode saves to config.toml permanently.
 - The file is read on startup. Created automatically when you first run `/model`.
+- `provider` is optional. If specified, `mini-agent` searches for model metadata under this provider inside [models.dev](https://models.dev/) first. If not found or omitted, it falls back to prefix matching, then searches all providers.
+
+  | Default Provider | Model ID Prefixes |
+  |---|---|
+  | `anthropic` | `claude-` |
+  | `deepseek` | `deepseek-` |
+  | `google` | `gemini-` |
+  | `openai` | `gpt-`, `o3`, `o4`, `text-`, `chatgpt-` |

--- a/src/mini_agent/cli/models.py
+++ b/src/mini_agent/cli/models.py
@@ -2,11 +2,34 @@ import json
 import urllib.request
 from urllib.parse import urlparse
 
-from ..config import CONFIG_DIR, REASONING_EFFORT_LEVELS, client, config
+from ..config import (
+    CONFIG_DIR,
+    DEFAULT_PROVIDERS,
+    REASONING_EFFORT_LEVELS,
+    client,
+    config,
+)
 from .display import clear_prompt_line
 from .display.picker import select_from_list
 
-_ENTER_MANUALLY = "Enter model ID manually..."
+
+def _get_provider_hint(model_id: str) -> str | None:
+    for provider_id, prefixes in DEFAULT_PROVIDERS.items():
+        if model_id.startswith(tuple(prefixes)):
+            return provider_id
+    return None
+
+
+def _get_limit_for_provider(
+    cache: dict[str, dict], provider_id: str, model_id: str, key: str
+) -> int | None:
+    provider = cache.get(provider_id)
+    if not provider:
+        return None
+    model = provider.get("models", {}).get(model_id)
+    if not model:
+        return None
+    return model.get("limit", {}).get(key)
 
 
 class _ModelInfo:
@@ -26,8 +49,27 @@ class _ModelInfo:
 
     def get_best_limit(self, model_id: str, key: str) -> int | None:
         """Return the maximum value for *key* (e.g. 'context' or 'output') across all providers for a given model."""
+        cache = self._load_cache()
+
+        # 1. Try with user-specified provider
+        user_provider = config.get_provider()
+        if user_provider:
+            best = _get_limit_for_provider(cache, user_provider, model_id, key)
+            if best is not None:
+                return best
+
+        # 2. Fall back to prefix matching using DEFAULT_PROVIDERS
+        provider_hint = _get_provider_hint(model_id)
+        if provider_hint and provider_hint != user_provider:
+            best = _get_limit_for_provider(cache, provider_hint, model_id, key)
+            if best is not None:
+                return best
+
+        # 3. Fall back to searching across ALL providers in the catalog
         best = None
-        for provider in self._load_cache().values():
+        for provider_id, provider in cache.items():
+            if provider_id in (user_provider, provider_hint):
+                continue
             model = provider.get("models", {}).get(model_id)
             if model is None:
                 continue
@@ -121,7 +163,7 @@ def select_model(model_ids: list[str]) -> str | None:
     current = config.get_model()
     selected_index = model_ids.index(current) if current in model_ids else 0
 
-    items: list[str] = [*model_ids, _ENTER_MANUALLY]
+    items: list[str] = [*model_ids, "Enter model ID manually..."]
     result = select_from_list(
         items,
         "Select model",
@@ -131,7 +173,7 @@ def select_model(model_ids: list[str]) -> str | None:
     )
     if result is None:
         return None
-    if result == _ENTER_MANUALLY:
+    if result == "Enter model ID manually...":
         try:
             model_id = input("Model ID: ").strip()
         except KeyboardInterrupt, EOFError:

--- a/src/mini_agent/cli/models.py
+++ b/src/mini_agent/cli/models.py
@@ -26,10 +26,10 @@ def _get_limit_for_provider(
     provider = cache.get(provider_id)
     if not provider:
         return None
-    model = provider.get("models", {}).get(model_id)
+    model = (provider.get("models") or {}).get(model_id)
     if not model:
         return None
-    return model.get("limit", {}).get(key)
+    return (model.get("limit") or {}).get(key)
 
 
 class _ModelInfo:
@@ -70,10 +70,10 @@ class _ModelInfo:
         for provider_id, provider in cache.items():
             if provider_id in (user_provider, provider_hint):
                 continue
-            model = provider.get("models", {}).get(model_id)
+            model = (provider.get("models") or {}).get(model_id)
             if model is None:
                 continue
-            value = model.get("limit", {}).get(key)
+            value = (model.get("limit") or {}).get(key)
             if value is not None and (best is None or value > best):
                 best = value
         return best

--- a/src/mini_agent/config.py
+++ b/src/mini_agent/config.py
@@ -52,6 +52,7 @@ class Config:
         self._reasoning_effort: str | None = None
         self._session_reasoning_effort_override: str | None = None
         self._provider: str | None = None
+        self._provider_loaded: bool = False
 
     def _load_config(self) -> dict[str, object]:
         if CONFIG_FILE.exists():
@@ -59,11 +60,12 @@ class Config:
         return {}
 
     def get_provider(self) -> str | None:
-        if self._provider is None:
+        if not self._provider_loaded:
             cfg = self._load_config()
             val = cfg.get("provider")
             if isinstance(val, str):
                 self._provider = val
+            self._provider_loaded = True
         return self._provider
 
     def set_session_model(self, model_id: str) -> None:

--- a/src/mini_agent/config.py
+++ b/src/mini_agent/config.py
@@ -22,6 +22,12 @@ REASONING_EFFORT_LEVELS = [
     "xhigh",
     "max",
 ]
+DEFAULT_PROVIDERS = {
+    "anthropic": ["claude-"],
+    "deepseek": ["deepseek-"],
+    "google": ["gemini-"],
+    "openai": ["gpt-", "o3", "o4", "text-", "chatgpt-"],
+}
 CONFIG_DIR = DEFAULT_CONFIG_DIR
 SESSION_DIR = CONFIG_DIR / "sessions"
 CONFIG_FILE = CONFIG_DIR / "config.toml"
@@ -45,11 +51,20 @@ class Config:
         self._session_model_override: str | None = None
         self._reasoning_effort: str | None = None
         self._session_reasoning_effort_override: str | None = None
+        self._provider: str | None = None
 
     def _load_config(self) -> dict[str, object]:
         if CONFIG_FILE.exists():
             return tomllib.loads(CONFIG_FILE.read_text())
         return {}
+
+    def get_provider(self) -> str | None:
+        if self._provider is None:
+            cfg = self._load_config()
+            val = cfg.get("provider")
+            if isinstance(val, str):
+                self._provider = val
+        return self._provider
 
     def set_session_model(self, model_id: str) -> None:
         self._session_model_override = model_id


### PR DESCRIPTION
## Description

This PR introduces support for a custom top-level `provider` configuration field and implements a robust, intelligent three-tiered nested fallback strategy for resolving model limit metadata (context limit and output limit) from `models.dev`.

Key changes:
1. **Custom `provider` Config Support**: Added support for an optional `provider` field (string) in `config.toml` (managed via `config.py`).
2. **Prefix-based Provider Mapping**: Introduced `DEFAULT_PROVIDERS` in `config.py` to map model ID prefixes to default providers (`anthropic` for `claude-`, `deepseek` for `deepseek-`, `google` for `gemini-`, and `openai` for `gpt-`/`o3`/`o4`/`text-`/`chatgpt-`).
3. **Three-tiered Nested Fallback Strategy**: Reimplemented `get_best_limit` in `models.py` to:
   - **First tier**: Query metadata strictly from the user-specified provider catalog if defined.
   - **Second tier**: Fall back to the default prefix-matching catalog (defined in `DEFAULT_PROVIDERS`).
   - **Third tier**: Fall back to a global search across all providers' catalogs in the `models.json` cache.
4. **Cleanup**: Removed the legacy private variable `_ENTER_MANUALLY` and inlined its string value in `select_model` for cleaner code.
5. **Documentation Update**: Fully documented the new `provider` configuration field, the nested fallback logic, and default prefix mapping rules in `docs/config.md`.

## Type of change

- [x] New feature
- [x] Documentation update

## Test

- Verified automatic fallback behavior in different scenarios:
  1. `provider` set to `"google"` (explicit matching) correctly returns Gemini model context limit of `1,048,576`.
  2. `provider` set to `"random"` (or any mismatched provider name like `"openai"`) is not found initially, so it falls back to default prefix rules and successfully resolves and returns Gemini limits (`1,048,576` from `google`).
  3. Querying an unrecognized model ID prefix correctly falls back to global search and returns the limit successfully (e.g., `google/gemini-2.0-flash-lite-001` resolved from `openrouter`).
- Verified that `make lint` and `ruff check --fix .` pass successfully.

---
Assisted-by: mini-agent:gemini-3.5-flash
