### PR TITLE
fix(printing): handle FileNotFoundError in edit_file diff display

### DIFF
--- a/src/mini_agent/cli/display/printing.py
+++ b/src/mini_agent/cli/display/printing.py
@@ -165,11 +165,14 @@ def print_tool_result(name: str, input_data: dict[str, object], output: str) -> 
             return
         old_text = cast(str, input_data["old_text"])
         new_text = cast(str, input_data["new_text"])
-        edited_content = Path(path).read_text()
-        pos = edited_content.find(new_text)
-        start_line = edited_content[:pos].count("\n") + 1 if pos != -1 else 1
-        diff = format_edit_diff(old_text, new_text, start_line)
-        print(f"{diff}\n")
+        try:
+            edited_content = Path(path).read_text()
+            pos = edited_content.find(new_text)
+            start_line = edited_content[:pos].count("\n") + 1 if pos != -1 else 1
+            diff = format_edit_diff(old_text, new_text, start_line)
+            print(f"{diff}\n")
+        except FileNotFoundError:
+            print(f"> {name} - {path} (file no longer available)\n")
         return
 
     if name in ("read_file", "write_file", "activate_skill"):


### PR DESCRIPTION
## Description

When displaying the diff for an `edit_file` tool result in the session history, `Path(path).read_text()` would raise a `FileNotFoundError` if the file was deleted between the edit and the display. This wraps the read in a try/except to gracefully handle that case.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test

Manually verified that printing a session containing an `edit_file` tool result for a now-deleted file no longer crashes.

---

Assisted-by: mini-agent:deepseek-v4-flash
