### PR TITLE
feat: support variables in context instructions

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -13,7 +13,7 @@ Directories are scanned recursively.
 
 ## Variables
 
-`${VARIABLE}` placeholders in SKILL.md are substituted at load time:
+`${VARIABLE}` and `$VARIABLE` placeholders in `SKILL.md` are substituted at load time:
 
 | Variable | Source |
 |----------|--------|

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -65,3 +65,5 @@ mini-agent loads `AGENTS.md` at startup from:
 - the current directory
 
 Use context files for project conventions, commands, and preferences.
+
+`${VARIABLE}` and `$VARIABLE` placeholders in `AGENTS.md` are substituted at load time. `MODEL_NAME` resolves to the active model ID.

--- a/src/mini_agent/agent/skills.py
+++ b/src/mini_agent/agent/skills.py
@@ -4,9 +4,8 @@ from typing import Any
 
 import yaml
 
-from ..config import SKILLS_DIRS, config
-
-_VAR_RE = re.compile(r"\$([A-Z_][A-Z0-9_]*|\{[A-Z_][A-Z0-9_]*\})")
+from ..config import SKILLS_DIRS
+from .variables import get_variables, substitute_variables
 
 
 class SkillLoader:
@@ -14,19 +13,6 @@ class SkillLoader:
         self.skills_dirs = skills_dirs
         self.skills: dict[str, dict[str, Any]] = {}
         self._load_all()
-
-    def _variables(self) -> dict[str, str]:
-        return {"MODEL_NAME": config.get_model()}
-
-    @staticmethod
-    def _substitute(text: str, variables: dict[str, str]) -> str:
-        def repl(m: re.Match) -> str:
-            key = m.group(1)
-            if key.startswith("{") and key.endswith("}"):
-                key = key[1:-1]
-            return variables.get(key, m.group(0))
-
-        return _VAR_RE.sub(repl, text)
 
     def _load_all(self) -> None:
         for skills_dir in self.skills_dirs:
@@ -62,13 +48,13 @@ class SkillLoader:
     def get_descriptions(self) -> str:
         if not self.skills:
             return "(no skills available)"
-        variables = self._variables()
+        variables = get_variables()
         lines = [
             "<available_skills>",
             "  <instructions>The following skills provide specialized instructions for specific tasks. When a task matches a skill's description, call the activate_skill tool with the skill's name to load its full instructions.</instructions>",
         ]
         for name, skill in self.skills.items():
-            desc = self._substitute(skill["description"], variables)
+            desc = substitute_variables(skill["description"], variables)
             lines.append("  <skill>")
             lines.append(f"    <name>{name}</name>")
             lines.append(f"    <description>{desc}</description>")
@@ -81,8 +67,8 @@ class SkillLoader:
         skill = self.skills.get(name)
         if not skill:
             return f"Error: Unknown skill '{name}'. Available: {', '.join(self.skills.keys())}"
-        variables = self._variables()
-        body = self._substitute(skill["body"], variables)
+        variables = get_variables()
+        body = substitute_variables(skill["body"], variables)
         return f'<skill_content name="{name}">\n{body}\n</skill_content>'
 
 

--- a/src/mini_agent/agent/system_prompt.py
+++ b/src/mini_agent/agent/system_prompt.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from ..config import CONFIG_DIR, WORKDIR
 from .skills import skill_loader
 from .tools import TOOLS
+from .variables import get_variables, substitute_variables
 
 CONTEXT_FILENAMES = ("AGENTS.md",)
 
@@ -57,9 +58,10 @@ def _build_context_section(files: list[Path]) -> str:
         return ""
 
     sections = ["\n<project_instructions>\n"]
+    variables = get_variables()
     for i, path in enumerate(files, 1):
         try:
-            content = path.read_text().strip()
+            content = substitute_variables(path.read_text().strip(), variables)
         except PermissionError, OSError:
             continue
         sections.append(

--- a/src/mini_agent/agent/variables.py
+++ b/src/mini_agent/agent/variables.py
@@ -1,0 +1,22 @@
+import re
+
+from ..config import config
+
+_VAR_RE = re.compile(r"\$([A-Z_][A-Z0-9_]*|\{[A-Z_][A-Z0-9_]*\})")
+
+
+def get_variables() -> dict[str, str]:
+    return {"MODEL_NAME": config.get_model()}
+
+
+def substitute_variables(text: str, variables: dict[str, str] | None = None) -> str:
+    if variables is None:
+        variables = get_variables()
+
+    def repl(m: re.Match[str]) -> str:
+        key = m.group(1)
+        if key.startswith("{") and key.endswith("}"):
+            key = key[1:-1]
+        return variables.get(key, m.group(0))
+
+    return _VAR_RE.sub(repl, text)


### PR DESCRIPTION
## Summary
- share variable substitution between skills and project instructions
- expand variables in `AGENTS.md` using the same built-in variables as skills
- document `$VARIABLE` and `${VARIABLE}` support for skills and context files

## Verification
- `make check`
- `make type-check`
- local smoke test for `SKILL.md` and `AGENTS.md` expansion, confirming only `MODEL_NAME` expands while shell, dotenv-only, and missing variables remain literal