### PR TITLE
feat: load mini-agent skills directories

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -7,10 +7,11 @@ mini-agent follows the [Agent Skills](https://agentskills.io/specification) stan
 ## Locations
 
 - `~/.agents/skills/<name>/SKILL.md`
+- `~/.mini-agent/skills/<name>/SKILL.md`
 - `.agents/skills/<name>/SKILL.md`
 - `.mini-agent/skills/<name>/SKILL.md`
 
-Directories are scanned recursively. If the same skill name exists in both project skill directories, `.mini-agent/skills` takes precedence over `.agents/skills`.
+Directories are scanned recursively. If the same skill name exists in both `.agents/skills` and `.mini-agent/skills`, the `.mini-agent/skills` version takes precedence within the same scope.
 
 ## Variables
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -8,8 +8,9 @@ mini-agent follows the [Agent Skills](https://agentskills.io/specification) stan
 
 - `~/.agents/skills/<name>/SKILL.md`
 - `.agents/skills/<name>/SKILL.md`
+- `.mini-agent/skills/<name>/SKILL.md`
 
-Directories are scanned recursively.
+Directories are scanned recursively. If the same skill name exists in both project skill directories, `.mini-agent/skills` takes precedence over `.agents/skills`.
 
 ## Variables
 

--- a/src/mini_agent/config.py
+++ b/src/mini_agent/config.py
@@ -29,7 +29,8 @@ CONFIG_FILE = CONFIG_DIR / "config.toml"
 WORKDIR = Path.cwd()
 HOME_SKILLS_DIR = Path.home() / ".agents" / "skills"
 PROJECT_SKILLS_DIR = WORKDIR / ".agents" / "skills"
-SKILLS_DIRS = [HOME_SKILLS_DIR, PROJECT_SKILLS_DIR]
+PROJECT_MINI_AGENT_SKILLS_DIR = WORKDIR / ".mini-agent" / "skills"
+SKILLS_DIRS = [HOME_SKILLS_DIR, PROJECT_SKILLS_DIR, PROJECT_MINI_AGENT_SKILLS_DIR]
 
 load_dotenv(CONFIG_DIR / ".env")
 

--- a/src/mini_agent/config.py
+++ b/src/mini_agent/config.py
@@ -28,9 +28,15 @@ CONFIG_FILE = CONFIG_DIR / "config.toml"
 
 WORKDIR = Path.cwd()
 HOME_SKILLS_DIR = Path.home() / ".agents" / "skills"
+HOME_MINI_AGENT_SKILLS_DIR = Path.home() / ".mini-agent" / "skills"
 PROJECT_SKILLS_DIR = WORKDIR / ".agents" / "skills"
 PROJECT_MINI_AGENT_SKILLS_DIR = WORKDIR / ".mini-agent" / "skills"
-SKILLS_DIRS = [HOME_SKILLS_DIR, PROJECT_SKILLS_DIR, PROJECT_MINI_AGENT_SKILLS_DIR]
+SKILLS_DIRS = [
+    HOME_SKILLS_DIR,
+    HOME_MINI_AGENT_SKILLS_DIR,
+    PROJECT_SKILLS_DIR,
+    PROJECT_MINI_AGENT_SKILLS_DIR,
+]
 
 load_dotenv(CONFIG_DIR / ".env")
 


### PR DESCRIPTION
## Summary
- load skills from `~/.mini-agent/skills` and project `.mini-agent/skills`
- preserve existing `.agents/skills` support
- give `.mini-agent/skills` precedence over `.agents/skills` within the same scope

## Verification
- `make check`
- `make type-check`
- local smoke test covering duplicate skill names across home/project `.agents` and `.mini-agent` directories

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kowyo/mini-agent/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

