### PR TITLE
fix: handle interrupted response streams

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.14"
 authors = [{ name = "Kowyo", email = "kowyo@outlook.com" }]
 dependencies = [
     "anthropic>=0.111.0",
+    "httpx>=0.28.1",
     "pillow>=12.2.0",
     "prompt-toolkit>=3.0.52",
     "pyobjc-framework-cocoa>=12.2.1 ; sys_platform == 'darwin'",

--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -61,7 +61,7 @@ def agent_loop(messages: list[MessageParam]) -> None:
                     display_stream_events(stream)
                     response = stream.get_final_message()
 
-            except (TypeError, anthropic.APIStatusError) as e:
+            except (TypeError, anthropic.APIError) as e:
                 thinking_status.stop()
                 print(f"Unexpected {e=}\n")
                 messages.pop()

--- a/src/mini_agent/agent/agent.py
+++ b/src/mini_agent/agent/agent.py
@@ -1,4 +1,5 @@
 import anthropic
+import httpx
 from anthropic.types import (
     MessageParam,
     ToolResultBlockParam,
@@ -17,7 +18,12 @@ from .tools import TOOL_HANDLERS, TOOLS, BashInterruptedError
 console = Console()
 
 
+def _discard_incomplete_turn(messages: list[MessageParam], turn_start: int) -> None:
+    del messages[turn_start:]
+
+
 def agent_loop(messages: list[MessageParam]) -> None:
+    turn_start = max(len(messages) - 1, 0)
     model = config.get_model()
     max_tokens = get_max_output_tokens(model) or 32768
 
@@ -61,10 +67,24 @@ def agent_loop(messages: list[MessageParam]) -> None:
                     display_stream_events(stream)
                     response = stream.get_final_message()
 
+            except anthropic.APITimeoutError, httpx.TimeoutException:
+                thinking_status.stop()
+                console.print(
+                    "[bold red]Request timed out. Please try again.[/bold red]"
+                )
+                _discard_incomplete_turn(messages, turn_start)
+                return
+            except anthropic.APIConnectionError, httpx.TransportError:
+                thinking_status.stop()
+                console.print(
+                    "[bold red]Could not complete the response because the connection was interrupted. Please try again.[/bold red]"
+                )
+                _discard_incomplete_turn(messages, turn_start)
+                return
             except (TypeError, anthropic.APIError) as e:
                 thinking_status.stop()
                 print(f"Unexpected {e=}\n")
-                messages.pop()
+                _discard_incomplete_turn(messages, turn_start)
                 return
 
             messages.append({"role": "assistant", "content": response.content})

--- a/src/mini_agent/config.py
+++ b/src/mini_agent/config.py
@@ -43,7 +43,11 @@ load_dotenv(CONFIG_DIR / ".env")
 if os.getenv("ANTHROPIC_API_KEY"):
     os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
 
-client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
+client = Anthropic(
+    base_url=os.getenv("ANTHROPIC_BASE_URL"),
+    timeout=60.0,
+    max_retries=2,
+)
 
 
 class Config:

--- a/src/mini_agent/config.py
+++ b/src/mini_agent/config.py
@@ -3,6 +3,7 @@ import os
 import tomllib
 from pathlib import Path
 
+import httpx
 import tomli_w
 from anthropic import Anthropic
 from dotenv import load_dotenv
@@ -45,8 +46,7 @@ if os.getenv("ANTHROPIC_API_KEY"):
 
 client = Anthropic(
     base_url=os.getenv("ANTHROPIC_BASE_URL"),
-    timeout=60.0,
-    max_retries=2,
+    timeout=httpx.Timeout(600.0, connect=30.0),
 )
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,82 @@
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from anthropic.types import MessageParam, ToolUseBlock
+
+from mini_agent.agent import agent
+
+
+class StatusStub:
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+
+class ResponseStreamStub:
+    def __init__(self, response: SimpleNamespace) -> None:
+        self.response = response
+
+    def __enter__(self) -> ResponseStreamStub:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+    def __iter__(self) -> Iterator[object]:
+        return iter(())
+
+    def get_final_message(self) -> SimpleNamespace:
+        return self.response
+
+
+class TimeoutStreamStub:
+    def __enter__(self) -> TimeoutStreamStub:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+    def __iter__(self) -> Iterator[object]:
+        raise httpx.ReadTimeout("The read operation timed out")
+
+
+def test_stream_timeout_discards_the_entire_incomplete_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_use = ToolUseBlock(type="tool_use", id="tool-1", name="unknown", input={})
+    response = SimpleNamespace(
+        content=[tool_use],
+        stop_reason="tool_use",
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+    )
+    streams = iter([ResponseStreamStub(response), TimeoutStreamStub()])
+
+    monkeypatch.setattr(
+        agent,
+        "client",
+        SimpleNamespace(
+            messages=SimpleNamespace(stream=lambda **kwargs: next(streams))
+        ),
+    )
+    monkeypatch.setattr(agent.console, "status", lambda message: StatusStub())
+    monkeypatch.setattr(agent.console, "print", lambda message: None)
+    monkeypatch.setattr(agent, "print_tool_start", lambda name, input_data: None)
+    monkeypatch.setattr(
+        agent, "print_tool_result", lambda name, input_data, output: None
+    )
+    previous_messages: list[MessageParam] = [
+        {"role": "user", "content": "Previous question"},
+        {"role": "assistant", "content": "Previous answer"},
+    ]
+    messages = [*previous_messages, {"role": "user", "content": "New question"}]
+    previous_usages = list(agent.token_tracker.round_usages)
+
+    try:
+        agent.agent_loop(messages)
+        assert messages == previous_messages
+    finally:
+        agent.token_tracker.restore(previous_usages)

--- a/uv.lock
+++ b/uv.lock
@@ -238,6 +238,7 @@ version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "httpx" },
     { name = "pillow" },
     { name = "prompt-toolkit" },
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
@@ -259,6 +260,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.111.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'", specifier = ">=12.2.1" },


### PR DESCRIPTION
## Summary

- handle both Anthropic-wrapped and raw HTTPX timeout and transport errors during streamed responses
- discard the complete in-progress agent turn when a request fails, avoiding incomplete tool-use history
- retain a 10-minute streaming read timeout while allowing 30 seconds to connect
- add regression coverage for a timeout after a tool-call round

## Root cause

The Anthropic SDK wraps errors raised while establishing a request, but a timeout or connection failure raised later while iterating the response body can escape as a raw HTTPX transport exception. The previous scalar 60-second timeout also shortened the SDK's default 10-minute streaming read timeout. Finally, removing only the last message after a failure could leave an assistant `tool_use` without its corresponding `tool_result`.

## Impact

Interrupted or slow response streams now return users to the CLI with a concise error instead of a traceback. Conversation history rolls back to the last complete turn so subsequent requests remain valid.

## Validation

- `make check`
- `uv run pytest -q`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kowyo/mini-agent/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

